### PR TITLE
Add callable support to `show_default`

### DIFF
--- a/typer/core.py
+++ b/typer/core.py
@@ -106,7 +106,7 @@ class TyperArgument(click.core.Argument):
         ] = None,
         autocompletion: Optional[Callable[..., Any]] = None,
         # TyperArgument
-        show_default: Union[bool, str, Callable[..., Union[bool, str]]] = True,
+        show_default: Union[bool, str, Callable[[], Union[bool, str]]] = True,
         show_choices: bool = True,
         show_envvar: bool = True,
         help: Optional[str] = None,
@@ -224,7 +224,7 @@ class TyperOption(click.core.Option):
         ] = None,
         autocompletion: Optional[Callable[..., Any]] = None,
         # Option
-        show_default: Union[bool, str, Callable[..., Union[bool, str]]] = False,
+        show_default: Union[bool, str, Callable[[], Union[bool, str]]] = False,
         prompt: Union[bool, str] = False,
         confirmation_prompt: Union[bool, str] = False,
         prompt_required: bool = True,

--- a/typer/core.py
+++ b/typer/core.py
@@ -347,7 +347,7 @@ class TyperOption(click.core.Option):
             elif isinstance(default_value, (list, tuple)):
                 default_string = ", ".join(str(d) for d in default_value)
             elif callable(default_value):
-                default_string = _("(dynamic)")
+                default_string = "(dynamic)"
             elif self.is_bool_flag and self.secondary_opts:
                 # For boolean flags that have distinct True/False opts,
                 # use the opt without prefix instead of the value.

--- a/typer/core.py
+++ b/typer/core.py
@@ -82,6 +82,7 @@ def _typer_param_setup_autocompletion_compat(
 
         self._custom_shell_complete = compat_autocompletion
 
+
 class TyperArgument(click.core.Argument):
     def __init__(
         self,
@@ -157,7 +158,11 @@ class TyperArgument(click.core.Argument):
                 )
                 extra.append(f"env var: {var_str}")
 
-        show_default = self.show_default() if inspect.isfunction(self.show_default) else self.show_default
+        show_default = (
+            self.show_default()
+            if inspect.isfunction(self.show_default)
+            else self.show_default
+        )
         if self.default is not None and (show_default or ctx.show_default):
             if isinstance(show_default, str):
                 default_string = show_default
@@ -335,8 +340,11 @@ class TyperOption(click.core.Option):
         finally:
             ctx.resilient_parsing = resilient
 
-
-        show_default = self.show_default() if inspect.isfunction(self.show_default) else self.show_default
+        show_default = (
+            self.show_default()
+            if inspect.isfunction(self.show_default)
+            else self.show_default
+        )
         show_default_is_str = isinstance(show_default, str)
 
         if show_default_is_str or (

--- a/typer/core.py
+++ b/typer/core.py
@@ -160,7 +160,7 @@ class TyperArgument(click.core.Argument):
         show_default = self.show_default() if inspect.isfunction(self.show_default) else self.show_default
         if self.default is not None and (show_default or ctx.show_default):
             if isinstance(show_default, str):
-                default_string = f"({show_default})"
+                default_string = show_default
             elif isinstance(self.default, (list, tuple)):
                 default_string = ", ".join(str(d) for d in self.default)
             elif inspect.isfunction(self.default):
@@ -343,7 +343,7 @@ class TyperOption(click.core.Option):
             default_value is not None and (show_default or ctx.show_default)
         ):
             if show_default_is_str:
-                default_string = f"{show_default})"
+                default_string = show_default
             elif isinstance(default_value, (list, tuple)):
                 default_string = ", ".join(str(d) for d in default_value)
             elif callable(default_value):

--- a/typer/models.py
+++ b/typer/models.py
@@ -174,7 +174,7 @@ class ParameterInfo:
         ] = None,
         autocompletion: Optional[Callable[..., Any]] = None,
         # TyperArgument
-        show_default: Union[bool, str] = True,
+        show_default: Union[bool, str, Callable[..., Union[bool, str]]] = True,
         show_choices: bool = True,
         show_envvar: bool = True,
         help: Optional[str] = None,
@@ -263,7 +263,7 @@ class OptionInfo(ParameterInfo):
         ] = None,
         autocompletion: Optional[Callable[..., Any]] = None,
         # Option
-        show_default: bool = True,
+        show_default: Union[bool, str, Callable[..., Union[bool, str]]] = True,
         prompt: Union[bool, str] = False,
         confirmation_prompt: bool = False,
         prompt_required: bool = True,
@@ -370,7 +370,7 @@ class ArgumentInfo(ParameterInfo):
         ] = None,
         autocompletion: Optional[Callable[..., Any]] = None,
         # TyperArgument
-        show_default: Union[bool, str] = True,
+        show_default: Union[bool, str, Callable[..., Union[bool, str]]] = True,
         show_choices: bool = True,
         show_envvar: bool = True,
         help: Optional[str] = None,

--- a/typer/models.py
+++ b/typer/models.py
@@ -174,7 +174,7 @@ class ParameterInfo:
         ] = None,
         autocompletion: Optional[Callable[..., Any]] = None,
         # TyperArgument
-        show_default: Union[bool, str, Callable[..., Union[bool, str]]] = True,
+        show_default: Union[bool, str, Callable[[], Union[bool, str]]] = True,
         show_choices: bool = True,
         show_envvar: bool = True,
         help: Optional[str] = None,
@@ -263,7 +263,7 @@ class OptionInfo(ParameterInfo):
         ] = None,
         autocompletion: Optional[Callable[..., Any]] = None,
         # Option
-        show_default: Union[bool, str, Callable[..., Union[bool, str]]] = True,
+        show_default: Union[bool, str, Callable[[], Union[bool, str]]] = True,
         prompt: Union[bool, str] = False,
         confirmation_prompt: bool = False,
         prompt_required: bool = True,
@@ -370,7 +370,7 @@ class ArgumentInfo(ParameterInfo):
         ] = None,
         autocompletion: Optional[Callable[..., Any]] = None,
         # TyperArgument
-        show_default: Union[bool, str, Callable[..., Union[bool, str]]] = True,
+        show_default: Union[bool, str, Callable[[], Union[bool, str]]] = True,
         show_choices: bool = True,
         show_envvar: bool = True,
         help: Optional[str] = None,

--- a/typer/params.py
+++ b/typer/params.py
@@ -25,7 +25,7 @@ def Option(
     ] = None,
     autocompletion: Optional[Callable[..., Any]] = None,
     # Option
-    show_default: Union[bool, str, Callable[..., Union[bool, str]]] = True,
+    show_default: Union[bool, str, Callable[[], Union[bool, str]]] = True,
     prompt: Union[bool, str] = False,
     confirmation_prompt: bool = False,
     prompt_required: bool = True,
@@ -130,7 +130,7 @@ def Argument(
     ] = None,
     autocompletion: Optional[Callable[..., Any]] = None,
     # TyperArgument
-    show_default: Union[bool, str, Callable[..., Union[bool, str]]] = True,
+    show_default: Union[bool, str, Callable[[], Union[bool, str]]] = True,
     show_choices: bool = True,
     show_envvar: bool = True,
     help: Optional[str] = None,

--- a/typer/params.py
+++ b/typer/params.py
@@ -25,7 +25,7 @@ def Option(
     ] = None,
     autocompletion: Optional[Callable[..., Any]] = None,
     # Option
-    show_default: bool = True,
+    show_default: Union[bool, str, Callable[..., Union[bool, str]]] = True,
     prompt: Union[bool, str] = False,
     confirmation_prompt: bool = False,
     prompt_required: bool = True,
@@ -130,7 +130,7 @@ def Argument(
     ] = None,
     autocompletion: Optional[Callable[..., Any]] = None,
     # TyperArgument
-    show_default: Union[bool, str] = True,
+    show_default: Union[bool, str, Callable[..., Union[bool, str]]] = True,
     show_choices: bool = True,
     show_envvar: bool = True,
     help: Optional[str] = None,


### PR DESCRIPTION
Adds callable support to `show_default`, allowing a `Callable[[], Union[bool, str]]` to be passed to dynamically determine the default to show in help messages. Closes https://github.com/tiangolo/typer/issues/354.

Previously, `show_default` was incorrectly typed as just `bool` instead of `Union[bool, str]` on `Option` / `OptionType`. This fixes those type annotations. Closes #158.

Additionally, the default string for dynamic options was defined as `default_string = _("(dynamic)")` which appears to be a bug and is confusing syntax if valid. This was simplified to match the line from arguments.

I've also removed the formatted parenthesis from the displayed `show_default` value, as this value should be able to match the style of a real default. This is the only "breaking" change here.

I'll happily extend documentation / tests if you're willing to accept this.