### PR TITLE
Simplify `comment-docs-preview-in-pr` action by removing `httpx` and use only `pygithub`

### DIFF
--- a/.github/actions/comment-docs-preview-in-pr/Dockerfile
+++ b/.github/actions/comment-docs-preview-in-pr/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7
 
-RUN pip install httpx "pydantic==1.5.1" pygithub
+RUN pip install "pydantic==1.5.1" pygithub
 
 COPY ./app /app
 

--- a/.github/actions/comment-docs-preview-in-pr/app/main.py
+++ b/.github/actions/comment-docs-preview-in-pr/app/main.py
@@ -47,5 +47,7 @@ if __name__ == "__main__":
     if not use_pr:
         logging.error(f"No PR found for hash: {event.workflow_run.head_commit.id}")
         sys.exit(0)
-    use_pr.create_issue_comment(f"📝 Docs preview for commit {use_pr.head.sha} at: {settings.input_deploy_url}")
+    use_pr.create_issue_comment(
+        f"📝 Docs preview for commit {use_pr.head.sha} at: {settings.input_deploy_url}"
+    )
     logging.info("Finished")

--- a/.github/actions/comment-docs-preview-in-pr/app/main.py
+++ b/.github/actions/comment-docs-preview-in-pr/app/main.py
@@ -3,12 +3,9 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-import httpx
 from github import Github
 from github.PullRequest import PullRequest
 from pydantic import BaseModel, BaseSettings, SecretStr, ValidationError
-
-github_api = "https://api.github.com"
 
 
 class Settings(BaseSettings):
@@ -50,19 +47,5 @@ if __name__ == "__main__":
     if not use_pr:
         logging.error(f"No PR found for hash: {event.workflow_run.head_commit.id}")
         sys.exit(0)
-    github_headers = {
-        "Authorization": f"token {settings.input_token.get_secret_value()}"
-    }
-    url = f"{github_api}/repos/{settings.github_repository}/issues/{use_pr.number}/comments"
-    logging.info(f"Using comments URL: {url}")
-    response = httpx.post(
-        url,
-        headers=github_headers,
-        json={
-            "body": f"📝 Docs preview for commit {use_pr.head.sha} at: {settings.input_deploy_url}"
-        },
-    )
-    if not (200 <= response.status_code <= 300):
-        logging.error(f"Error posting comment: {response.text}")
-        sys.exit(1)
+    use_pr.create_issue_comment(f"📝 Docs preview for commit {use_pr.head.sha} at: {settings.input_deploy_url}")
     logging.info("Finished")


### PR DESCRIPTION
**Why?**
* `pygithub` allows you to create issue comments by using `pull_request.create_issue_comment` method
* we can remove `httpx` library from action dependencies 