### PR TITLE
Unpin flit-core build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=2,<3"]
+requires = ["flit_core >=2"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]


### PR DESCRIPTION
I'd like to be able to build this project in [nixpkgs](https://github.com/NixOS/nixpkgs) using the latest version of flit-core. Please let me know what you think. Thank you.