### PR TITLE
Update _completion_shared.py

### DIFF
--- a/typer/_completion_shared.py
+++ b/typer/_completion_shared.py
@@ -110,7 +110,7 @@ def install_bash(*, prog_name: str, complete_var: str, shell: str) -> Path:
     rc_content = ""
     if rc_path.is_file():
         rc_content = rc_path.read_text()
-    completion_init_lines = [f"source {completion_path}"]
+    completion_init_lines = [f'source "{completion_path}"']
     for line in completion_init_lines:
         if line not in rc_content:  # pragma: nocover
             rc_content += f"\n{line}"


### PR DESCRIPTION
Wrap quotes around `completion_path` variable to solve potential issues from whitespace in the path name. I encountered this issue when using the `--install-completion` flag on a local module:
```shell
$ python3 -m cli --install-completion
```
This would create the file `~/.bash_completions/python3 -m cli.sh` and broke code that referenced the unquoted path in `.bashrc`. 

---

Something additional I thought of but could not figure out how to implement was adding the following code to `.bashrc`:
```bash
if [ -d "${HOME}/.bash_completions" ]; then
    for file in $(realpath -- "${HOME}/.bash_completions/*.sh"); do
        if [ -f "$file" ]; then
            source "$file"
        fi
    done
fi
```
This also solves the whitespace issue, but additionally removes the need to append a new line to `.bashrc` every time the `--install-completion` flag is used.