### PR TITLE
🔥 Adds support to read docs in dark mode

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,8 +6,18 @@ theme:
   name: material
   custom_dir: docs/overrides
   palette:
-    primary: black
-    accent: teal
+    - scheme: default
+      primary: black
+      accent: teal
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to dark mode
+    - scheme: slate
+      primary: black
+      accent: indigo
+      toggle:
+        icon: material/toggle-switch-off
+        name: Switch to light mode
   icon:
     repo: fontawesome/brands/github-alt
   logo: img/icon-white.svg


### PR DESCRIPTION
Reading docs in light mode puts a lot of strain on my eyes. So, here's the support to add dark mode for people like me.

![Screenshot from 2024-06-11 09-24-10](https://github.com/tiangolo/typer/assets/76887609/8d299b02-8767-41c8-af45-4d690e488952)
