### PR TITLE
✅ Fix tests for completion flags

### DIFF
--- a/tests/test_completion/test_completion.py
+++ b/tests/test_completion/test_completion.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from docs_src.commands.index import tutorial001 as mod
 
-from ..utils import needs_linux, needs_cleaning
+from ..utils import needs_cleaning, needs_linux
 
 
 @needs_linux

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,3 +9,5 @@ needs_py310 = pytest.mark.skipif(
 needs_linux = pytest.mark.skipif(
     not sys.platform.startswith("linux"), reason="Test requires Linux"
 )
+
+needs_cleaning = pytest.mark.skip(reason="needs decouple from system, causes side-effects")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,4 +10,6 @@ needs_linux = pytest.mark.skipif(
     not sys.platform.startswith("linux"), reason="Test requires Linux"
 )
 
-needs_cleaning = pytest.mark.skip(reason="needs decouple from system, causes side-effects")
+needs_cleaning = pytest.mark.skip(
+    reason="needs decouple from system, causes side-effects"
+)


### PR DESCRIPTION
--show-completions
zsh, fish, pwsh users could run tests with their default shell

--install-completions
(WIP: missing fish, pwsh)
this test is skipped due to side-effects
