### PR TITLE
🔧 Enable Coverage dynamic context to see the function that called a test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ omit = [
     "typer/_typing.py"
 ]
 context = '${CONTEXT}'
+dynamic_context = "test_function"
 relative_files = true
 
 [tool.coverage.report]


### PR DESCRIPTION
🔧 Enable Coverage dynamic context to see the function that called a test