### PR TITLE
✨ Show help items in order of definition

### DIFF
--- a/docs/tutorial/commands/index.md
+++ b/docs/tutorial/commands/index.md
@@ -257,6 +257,39 @@ Commands:
 
 </div>
 
+
+## Sorting of the commands
+
+Note that by design, **Typer** shows the commands in the order they've been declared.
+
+So, if we take our original example, with `create` and `delete` commands, and reverse the order in the Python file:
+
+```Python hl_lines="7  12"
+{!../docs_src/commands/index/tutorial004.py!}
+```
+
+Then we will see the `delete` command first in the help output:
+
+<div class="termy">
+
+```console
+// Check the help
+$ python main.py --help
+
+Usage: main.py [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --install-completion  Install completion for the current shell.
+  --show-completion     Show completion for the current shell, to copy it or customize the installation.
+  --help                Show this message and exit.
+
+Commands:
+  delete
+  create
+```
+
+</div>
+
 ## Click Group
 
 If you come from Click, a `typer.Typer` app with subcommands is more or less the equivalent of a <a href="https://click.palletsprojects.com/en/7.x/quickstart/#nesting-commands" class="external-link" target="_blank">Click Group</a>.

--- a/docs_src/commands/index/tutorial004.py
+++ b/docs_src/commands/index/tutorial004.py
@@ -1,0 +1,17 @@
+import typer
+
+app = typer.Typer()
+
+
+@app.command()
+def delete():
+    print("Deleting user: Hiro Hamada")
+
+
+@app.command()
+def create():
+    print("Creating user: Hiro Hamada")
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/assets/cli/multiapp-docs-title.md
+++ b/tests/assets/cli/multiapp-docs-title.md
@@ -18,8 +18,22 @@ The end
 
 **Commands**:
 
-* `sub`
 * `top`: Top command
+* `sub`
+
+## `multiapp top`
+
+Top command
+
+**Usage**:
+
+```console
+$ multiapp top [OPTIONS]
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
 
 ## `multiapp sub`
 
@@ -35,23 +49,9 @@ $ multiapp sub [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `bye`: Say bye
 * `hello`: Say Hello
 * `hi`: Say Hi
-
-### `multiapp sub bye`
-
-Say bye
-
-**Usage**:
-
-```console
-$ multiapp sub bye [OPTIONS]
-```
-
-**Options**:
-
-* `--help`: Show this message and exit.
+* `bye`: Say bye
 
 ### `multiapp sub hello`
 
@@ -87,14 +87,14 @@ $ multiapp sub hi [OPTIONS] [USER]
 
 * `--help`: Show this message and exit.
 
-## `multiapp top`
+### `multiapp sub bye`
 
-Top command
+Say bye
 
 **Usage**:
 
 ```console
-$ multiapp top [OPTIONS]
+$ multiapp sub bye [OPTIONS]
 ```
 
 **Options**:

--- a/tests/assets/cli/multiapp-docs.md
+++ b/tests/assets/cli/multiapp-docs.md
@@ -18,8 +18,22 @@ The end
 
 **Commands**:
 
-* `sub`
 * `top`: Top command
+* `sub`
+
+## `multiapp top`
+
+Top command
+
+**Usage**:
+
+```console
+$ multiapp top [OPTIONS]
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
 
 ## `multiapp sub`
 
@@ -35,23 +49,9 @@ $ multiapp sub [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `bye`: Say bye
 * `hello`: Say Hello
 * `hi`: Say Hi
-
-### `multiapp sub bye`
-
-Say bye
-
-**Usage**:
-
-```console
-$ multiapp sub bye [OPTIONS]
-```
-
-**Options**:
-
-* `--help`: Show this message and exit.
+* `bye`: Say bye
 
 ### `multiapp sub hello`
 
@@ -87,14 +87,14 @@ $ multiapp sub hi [OPTIONS] [USER]
 
 * `--help`: Show this message and exit.
 
-## `multiapp top`
+### `multiapp sub bye`
 
-Top command
+Say bye
 
 **Usage**:
 
 ```console
-$ multiapp top [OPTIONS]
+$ multiapp sub bye [OPTIONS]
 ```
 
 **Options**:

--- a/tests/test_tutorial/test_commands/test_index/test_tutorial004.py
+++ b/tests/test_tutorial/test_commands/test_index/test_tutorial004.py
@@ -1,0 +1,45 @@
+import subprocess
+import sys
+
+from typer.testing import CliRunner
+
+from docs_src.commands.index import tutorial004 as mod
+
+app = mod.app
+
+runner = CliRunner()
+
+
+def test_help():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "[OPTIONS] COMMAND [ARGS]..." in result.output
+    print(result.output)
+    assert "Commands" in result.output
+    assert "create" in result.output
+    assert "delete" in result.output
+    # Test that the 'delete' command precedes the 'create' command in the help output
+    create_char = result.output.index("create")
+    delete_char = result.output.index("delete")
+    assert delete_char < create_char
+
+
+def test_create():
+    result = runner.invoke(app, ["create"])
+    assert result.exit_code == 0
+    assert "Creating user: Hiro Hamada" in result.output
+
+
+def test_delete():
+    result = runner.invoke(app, ["delete"])
+    assert result.exit_code == 0
+    assert "Deleting user: Hiro Hamada" in result.output
+
+
+def test_script():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert "Usage" in result.stdout

--- a/typer/core.py
+++ b/typer/core.py
@@ -739,8 +739,8 @@ class TyperGroup(click.core.Group):
             markup_mode=self.rich_markup_mode,
         )
 
-    def list_commands(self, ctx: click.Context) -> list[str]:
+    def list_commands(self, ctx: click.Context) -> List[str]:
         """Returns a list of subcommand names.
-         Note that in Click's Group class, these are sorted.
-         In Typer, we wish to maintain the original order of creation (cf Issue #933)"""
-        return self.commands
+        Note that in Click's Group class, these are sorted.
+        In Typer, we wish to maintain the original order of creation (cf Issue #933)"""
+        return [n for n, c in self.commands.items()]

--- a/typer/core.py
+++ b/typer/core.py
@@ -738,3 +738,9 @@ class TyperGroup(click.core.Group):
             ctx=ctx,
             markup_mode=self.rich_markup_mode,
         )
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        """Returns a list of subcommand names.
+         Note that in Click's Group class, these are sorted.
+         In Typer, we wish to maintain the original order of creation (cf Issue #933)"""
+        return self.commands


### PR DESCRIPTION
Fixes #933 

Click's `Group` class specifically [orders](https://github.com/pallets/click/blob/main/src/click/core.py#L1684) the items alphabetically:
```
    def list_commands(self, ctx: Context) -> list[str]:
        """Returns a list of subcommand names in the order they should appear."""
        return sorted(self.commands)
```

For `TyperGroup`, we override this behaviour and remove the `sorted` function. This works, because during creation of the group, the commands are kept in a list as they get declared, so `self.commands` has the original order.