### PR TITLE
fix: remove duplicate explanation how the path is resolved

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -227,8 +227,6 @@ It could look like this:
 /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/custompython/bin
 ```
 
-This way, when you type `python` in the terminal, the system will find the Python program in `/opt/custompython/bin` (the last directory) and use that one.
-
 ////
 
 //// tab | Windows
@@ -241,11 +239,7 @@ If you say yes to update the `PATH` environment variable, then the installer wil
 C:\Program Files\Python312\Scripts;C:\Program Files\Python312;C:\Windows\System32;C:\opt\custompython\bin
 ```
 
-This way, when you type `python` in the terminal, the system will find the Python program in `C:\opt\custompython\bin` (the last directory) and use that one.
-
 ////
-
-This way, when you type `python` in the terminal, the system will find the Python program in `/opt/custompython/bin` (the last directory) and use that one.
 
 So, if you type:
 
@@ -259,7 +253,7 @@ $ python
 
 //// tab | Linux, macOS
 
-The system will **find** the `python` program in `/opt/custompython/bin` and run it.
+The system will **find** the `python` program in `/opt/custompython/bin` (the last directory) and run it.
 
 It would be roughly equivalent to typing:
 
@@ -275,7 +269,7 @@ $ /opt/custompython/bin/python
 
 //// tab | Windows
 
-The system will **find** the `python` program in `C:\opt\custompython\bin\python` and run it.
+The system will **find** the `python` program in `C:\opt\custompython\bin\python` (the last directory) and run it.
 
 It would be roughly equivalent to typing:
 


### PR DESCRIPTION
I remove some duplication in the [here](https://typer.tiangolo.com/environment-variables/#__tabbed_4_1) in the docs.

![image](https://github.com/user-attachments/assets/e6fae892-891d-4f2c-8b7b-094240e49309)
