### PR TITLE
💚 Set `include-hidden-files` to `True` when using the `upload-artifact` GH action

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           name: docs-site
           path: ./site/**
+          include-hidden-files: true
 
   # https://github.com/marketplace/actions/alls-green#why
   docs-all-green:  # This job does nothing and is only used for the branch protection

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           name: coverage-${{ runner.os }}-${{ matrix.python-version }}
           path: coverage
+          include-hidden-files: true
 
   coverage-combine:
     needs: [test]
@@ -99,6 +100,7 @@ jobs:
         with:
           name: coverage-html
           path: htmlcov
+          include-hidden-files: true
 
   # https://github.com/marketplace/actions/alls-green#why
   check:  # This job does nothing and is only used for the branch protection


### PR DESCRIPTION
The CI was failing because hidden files are automatically excluded since `actions/upload-artifact` [v4.4.0](https://github.com/actions/upload-artifact/releases/tag/v4.4.0).

This PR specifically sets the parameter to `True` so the `.coverage` files are found.
