### PR TITLE
Bump minimum required python version from 3.7 to 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Typer, build great CLIs. Easy to code. Based on Python type hints
 authors = [
     {name = "Sebastián Ramírez", email = "tiangolo@gmail.com"},
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Intended Audience :: Information Technology",
     "Intended Audience :: System Administrators",


### PR DESCRIPTION
`mkdocs-material==9.5.33 depends on Python>=3.8` therefore we should:
- upgrade the minimum python version of typer to a compatible version and therefore change pyproject.toml file or
- downgrade `mkdocs-material` to a compatible version with python 3.7.

Considering that Python3.7 end of life was 2023-06-27, it seems reasonable to require as minimum version python3.8 (end of life due 2024-10).

See [discussion](https://github.com/fastapi/typer/discussions/969)