### PR TITLE
Fixed issue with custom classes

### DIFF
--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -76,3 +76,30 @@ def test_annotated_option_with_argname_doesnt_mutate_multiple_calls():
     result = runner.invoke(app, ["--force"])
     assert result.exit_code == 0, result.output
     assert "Forcing operation" in result.output
+
+def test_default_with_class_with_custom_eq():
+    app = typer.Typer()
+
+    from typer.models import ParamMeta
+    class StupidClass:
+        def __init__(self, a):
+            self.a = a
+
+        def __eq__(self, other) -> bool:
+            if other is ParamMeta.empty:
+                return True
+            try:
+                return self.a == other.a
+            except Exception:
+                return False
+
+        def __ne__(self, other: object) -> bool:
+            return not self.__eq__(other)
+
+    @app.command()
+    def cmd(val = StupidClass(42)):
+        print(val)
+    
+    result = runner.invoke(app)
+    assert result.exit_code == 0, result.output
+    assert "StupidClass" in result.output

--- a/typer/main.py
+++ b/typer/main.py
@@ -821,14 +821,14 @@ def get_click_param(
             required = True
         else:
             default_value = parameter_info.default
-    elif param.default == Required or param.default == param.empty:
+    elif param.default == Required or param.default is param.empty:
         required = True
         parameter_info = ArgumentInfo()
     else:
         default_value = param.default
         parameter_info = OptionInfo()
     annotation: Any
-    if not param.annotation == param.empty:
+    if param.annotation is not param.empty:
         annotation = param.annotation
     else:
         annotation = str


### PR DESCRIPTION
Similar to [This issue in `rich`](https://github.com/Textualize/rich/issues/2875), comparing types with `==` could be problematic. The canonical `is` would fix this problem.