### PR TITLE
🐛 Allow colon in zsh autocomplete values and descriptions

### DIFF
--- a/tests/test_completion/colon_example.py
+++ b/tests/test_completion/colon_example.py
@@ -1,0 +1,25 @@
+import typer
+
+image_desc = [
+    ("alpine:latest", "latest alpine image"),
+    ("alpine:hello", "fake image: for testing"),
+    ("nvidia/cuda:10.0-devel-ubuntu18.04", ""),
+]
+
+
+def _complete(incomplete: str) -> str:
+    for image, desc in image_desc:
+        if image.startswith(incomplete):
+            yield image, desc
+
+
+app = typer.Typer()
+
+
+@app.command()
+def image(name: str = typer.Option(autocompletion=_complete)):
+    typer.echo(name)
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/test_completion/test_completion_option_colon.py
+++ b/tests/test_completion/test_completion_option_colon.py
@@ -5,6 +5,16 @@ import sys
 from . import colon_example as mod
 
 
+def test_script():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--name", "DeadPool"],
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert result.returncode == 0
+    assert "DeadPool" in result.stdout
+
+
 def test_completion_colon_bash_all():
     result = subprocess.run(
         [sys.executable, "-m", "coverage", "run", mod.__file__, " "],

--- a/tests/test_completion/test_completion_option_colon.py
+++ b/tests/test_completion/test_completion_option_colon.py
@@ -1,0 +1,209 @@
+import os
+import subprocess
+import sys
+
+from . import colon_example as mod
+
+
+def test_completion_colon_bash_all():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
+        capture_output=True,
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "_COLON_EXAMPLE.PY_COMPLETE": "complete_bash",
+            "COMP_WORDS": "colon_example.py --name ",
+            "COMP_CWORD": "2",
+        },
+    )
+    assert "alpine:hello" in result.stdout
+    assert "alpine:latest" in result.stdout
+    assert "nvidia/cuda:10.0-devel-ubuntu18.04" in result.stdout
+
+
+def test_completion_colon_bash_partial():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
+        capture_output=True,
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "_COLON_EXAMPLE.PY_COMPLETE": "complete_bash",
+            "COMP_WORDS": "colon_example.py --name alpine ",
+            "COMP_CWORD": "2",
+        },
+    )
+    assert "alpine:hello" in result.stdout
+    assert "alpine:latest" in result.stdout
+    assert "nvidia/cuda:10.0-devel-ubuntu18.04" not in result.stdout
+
+
+def test_completion_colon_bash_single():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
+        capture_output=True,
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "_COLON_EXAMPLE.PY_COMPLETE": "complete_bash",
+            "COMP_WORDS": "colon_example.py --name alpine:hell ",
+            "COMP_CWORD": "2",
+        },
+    )
+    assert "alpine:hello" in result.stdout
+    assert "alpine:latest" not in result.stdout
+    assert "nvidia/cuda:10.0-devel-ubuntu18.04" not in result.stdout
+
+
+def test_completion_colon_zsh_all():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
+        capture_output=True,
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "_COLON_EXAMPLE.PY_COMPLETE": "complete_zsh",
+            "_TYPER_COMPLETE_ARGS": "colon_example.py --name ",
+        },
+    )
+    assert "alpine\\\\:hello" in result.stdout
+    assert "alpine\\\\:latest" in result.stdout
+    assert "nvidia/cuda\\\\:10.0-devel-ubuntu18.04" in result.stdout
+
+
+def test_completion_colon_zsh_partial():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
+        capture_output=True,
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "_COLON_EXAMPLE.PY_COMPLETE": "complete_zsh",
+            "_TYPER_COMPLETE_ARGS": "colon_example.py --name alpine",
+        },
+    )
+    assert "alpine\\\\:hello" in result.stdout
+    assert "alpine\\\\:latest" in result.stdout
+    assert "nvidia/cuda\\\\:10.0-devel-ubuntu18.04" not in result.stdout
+
+
+def test_completion_colon_zsh_single():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
+        capture_output=True,
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "_COLON_EXAMPLE.PY_COMPLETE": "complete_zsh",
+            "_TYPER_COMPLETE_ARGS": "colon_example.py --name alpine:hell",
+        },
+    )
+    assert "alpine\\\\:hello" in result.stdout
+    assert "alpine\\\\:latest" not in result.stdout
+    assert "nvidia/cuda\\\\:10.0-devel-ubuntu18.04" not in result.stdout
+
+
+def test_completion_colon_powershell_all():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
+        capture_output=True,
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "_COLON_EXAMPLE.PY_COMPLETE": "complete_powershell",
+            "_TYPER_COMPLETE_ARGS": "colon_example.py --name ",
+            "_TYPER_COMPLETE_WORD_TO_COMPLETE": "",
+        },
+    )
+    assert "alpine:hello" in result.stdout
+    assert "alpine:latest" in result.stdout
+    assert "nvidia/cuda:10.0-devel-ubuntu18.04" in result.stdout
+
+
+def test_completion_colon_powershell_partial():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
+        capture_output=True,
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "_COLON_EXAMPLE.PY_COMPLETE": "complete_powershell",
+            "_TYPER_COMPLETE_ARGS": "colon_example.py --name alpine",
+            "_TYPER_COMPLETE_WORD_TO_COMPLETE": "alpine",
+        },
+    )
+    assert "alpine:hello" in result.stdout
+    assert "alpine:latest" in result.stdout
+    assert "nvidia/cuda:10.0-devel-ubuntu18.04" not in result.stdout
+
+
+def test_completion_colon_powershell_single():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
+        capture_output=True,
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "_COLON_EXAMPLE.PY_COMPLETE": "complete_powershell",
+            "_TYPER_COMPLETE_ARGS": "colon_example.py --name alpine:hell",
+            "_TYPER_COMPLETE_WORD_TO_COMPLETE": "alpine:hell",
+        },
+    )
+    assert "alpine:hello" in result.stdout
+    assert "alpine:latest" not in result.stdout
+    assert "nvidia/cuda:10.0-devel-ubuntu18.04" not in result.stdout
+
+
+def test_completion_colon_pwsh_all():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
+        capture_output=True,
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "_COLON_EXAMPLE.PY_COMPLETE": "complete_pwsh",
+            "_TYPER_COMPLETE_ARGS": "colon_example.py --name",
+        },
+    )
+
+    assert "alpine:hello" in result.stdout
+    assert "alpine:latest" in result.stdout
+    assert "nvidia/cuda:10.0-devel-ubuntu18.04" in result.stdout
+
+
+def test_completion_colon_pwsh_partial():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
+        capture_output=True,
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "_COLON_EXAMPLE.PY_COMPLETE": "complete_pwsh",
+            "_TYPER_COMPLETE_ARGS": "colon_example.py --name alpine",
+            "_TYPER_COMPLETE_WORD_TO_COMPLETE": "alpine",
+        },
+    )
+    assert "alpine:hello" in result.stdout
+    assert "alpine:latest" in result.stdout
+    assert "nvidia/cuda:10.0-devel-ubuntu18.04" not in result.stdout
+
+
+def test_completion_colon_pwsh_single():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
+        capture_output=True,
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "_COLON_EXAMPLE.PY_COMPLETE": "complete_pwsh",
+            "_TYPER_COMPLETE_ARGS": "colon_example.py --name alpine:hell",
+            "_TYPER_COMPLETE_WORD_TO_COMPLETE": "alpine:hell",
+        },
+    )
+    assert "alpine:hello" in result.stdout
+    assert "alpine:latest" not in result.stdout
+    assert "nvidia/cuda:10.0-devel-ubuntu18.04" not in result.stdout
+
+
+# TODO: tests for complete_fish

--- a/typer/_completion_classes.py
+++ b/typer/_completion_classes.py
@@ -86,6 +86,7 @@ class ZshComplete(click.shell_completion.ZshComplete):
                 .replace("'", "''")
                 .replace("$", "\\$")
                 .replace("`", "\\`")
+                .replace(":", r"\\:")
             )
 
         # TODO: Explore replicating the new behavior from Click, pay attention to


### PR DESCRIPTION
Allow for colons in zsh completion values and descriptions, related to #162 

Note that because of the [`startswith` check](https://github.com/fastapi/typer/blob/master/typer/core.py#L90) escaping the completion options in the client side is not an option, as a value that includes a `:` for `incomplete` in will not pass this check.

Note that we need two levels of esacping, one for zsh, and one to preserve the escape for zsh

Tested by updating the `demo.py` example in the linked issue to the following:

```python
import typer

image_desc = [
    ("alpine:latest", "latest alpine image"),
    ("alpine:hello", "fake image: for testing"),
    ("nvidia/cuda:10.0-devel-ubuntu18.04", ""),
]

def _complete(incomplete: str) -> str:
    for (image, desc) in image_desc:
        if image.startswith(incomplete):
            yield image, desc

app = typer.Typer()

@app.command()
def image(name: str = typer.Option(autocompletion=_complete)):
    typer.echo(name)

if __name__ == "__main__":
    app()
```

use the provided docker image/setup to test, first that the colons show as values and descriptiosn correctly

```
0252e3324b42# typer demo.py run --name [TAB]
alpine:hello                        -- fake image: for testing
alpine:latest                       -- latest alpine image
nvidia/cuda:10.0-devel-ubuntu18.04
```

and that an incomplete value with a colon generates options

```
0252e3324b42# typer demo.py run --name alpine:[TAB]
alpine:hello   -- fake image: for testing
alpine:latest  -- latest alpine image
```