### PR TITLE
small clarification in the tutorial docs for cli arguments

### DIFF
--- a/docs/tutorial/arguments/optional.md
+++ b/docs/tutorial/arguments/optional.md
@@ -113,7 +113,7 @@ name: str
 
 Now, finally what we came for, an optional *CLI argument*.
 
-To make a *CLI argument* optional, use `typer.Argument()` and pass a different "default" as the first parameter to `typer.Argument()`, for example `None`:
+To make a *CLI argument* optional, use `typer.Argument()` and pass a defualt value for your function's argument, for example `None`:
 
 ```Python hl_lines="7"
 {!../docs_src/arguments/optional/tutorial002_an.py!}


### PR DESCRIPTION
In the optional cli arguments section, it said "To make a CLI argument optional, use typer.Argument() and pass a different "default" as the first parameter to typer.Argument(), for example None:" and the example was:
```python
from typing import Optional

import typer
from typing_extensions import Annotated


def main(name: Annotated[Optional[str], typer.Argument()] = None):
    if name is None:
        print("Hello World!")
    else:
        print(f"Hello {name}")


if __name__ == "__main__":
    typer.run(main)
```

I thought it was confusing because when I read it for the first time i though i should write it like this 
```python
def main(name: Annotated[Optional[str], typer.Argument(default=None)]) -> None
```
which is wrong, so i clarified the text a little.