### PR TITLE
✅ Only run completion installation tests when the env var `_TYPER_RUN_INSTALL_COMPLETION_TESTS` is set

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,5 +7,7 @@ set -x
 export TERMINAL_WIDTH=3000
 # Force disable terminal for tests inside of pytest, takes precedence over GITHUB_ACTIONS env var
 export _TYPER_FORCE_DISABLE_TERMINAL=1
+# Run autocompletion install tests in the CI
+export _TYPER_RUN_INSTALL_COMPLETION_TESTS=1
 # It seems xdist-pytest ensures modified sys.path to import relative modules in examples keeps working
 pytest --cov --cov-report=term-missing -o console_output_style=progress --numprocesses=auto ${@}

--- a/tests/test_completion/test_completion.py
+++ b/tests/test_completion/test_completion.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from docs_src.commands.index import tutorial001 as mod
 
-from ..utils import needs_bash, needs_linux
+from ..utils import needs_bash, needs_linux, requires_completion_permission
 
 
 @needs_bash
@@ -26,6 +26,7 @@ def test_show_completion():
 
 @needs_bash
 @needs_linux
+@requires_completion_permission
 def test_install_completion():
     bash_completion_path: Path = Path.home() / ".bashrc"
     text = ""

--- a/tests/test_completion/test_completion_install.py
+++ b/tests/test_completion/test_completion_install.py
@@ -10,11 +10,14 @@ from typer.testing import CliRunner
 
 from docs_src.commands.index import tutorial001 as mod
 
+from ..utils import requires_completion_permission
+
 runner = CliRunner()
 app = typer.Typer()
 app.command()(mod.main)
 
 
+@requires_completion_permission
 def test_completion_install_no_shell():
     result = subprocess.run(
         [sys.executable, "-m", "coverage", "run", mod.__file__, "--install-completion"],
@@ -28,6 +31,7 @@ def test_completion_install_no_shell():
     assert "Option '--install-completion' requires an argument" in result.stderr
 
 
+@requires_completion_permission
 def test_completion_install_bash():
     bash_completion_path: Path = Path.home() / ".bashrc"
     text = ""
@@ -67,6 +71,7 @@ def test_completion_install_bash():
     )
 
 
+@requires_completion_permission
 def test_completion_install_zsh():
     completion_path: Path = Path.home() / ".zshrc"
     text = ""
@@ -104,6 +109,7 @@ def test_completion_install_zsh():
     assert "compdef _tutorial001py_completion tutorial001.py" in install_content
 
 
+@requires_completion_permission
 def test_completion_install_fish():
     script_path = Path(mod.__file__)
     completion_path: Path = (
@@ -133,6 +139,7 @@ def test_completion_install_fish():
     assert "Completion will take effect once you restart the terminal" in result.stdout
 
 
+@requires_completion_permission
 def test_completion_install_powershell():
     completion_path: Path = (
         Path.home() / ".config/powershell/Microsoft.PowerShell_profile.ps1"

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -15,6 +15,8 @@ from typer.main import solve_typer_info_defaults, solve_typer_info_help
 from typer.models import ParameterInfo, TyperInfo
 from typer.testing import CliRunner
 
+from .utils import requires_completion_permission
+
 runner = CliRunner()
 
 
@@ -74,6 +76,7 @@ def test_valid_parser_permutations():
     ParameterInfo(click_type=CustomClickParser())
 
 
+@requires_completion_permission
 def test_install_invalid_shell():
     app = typer.Typer()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import sys
+from os import getenv
 
 import pytest
 
@@ -24,4 +25,9 @@ needs_linux = pytest.mark.skipif(
 
 needs_bash = pytest.mark.skipif(
     not shellingham or not shell or "bash" not in shell, reason="Test requires Bash"
+)
+
+requires_completion_permission = pytest.mark.skipif(
+    not getenv("_TYPER_RUN_INSTALL_COMPLETION_TESTS", False),
+    reason="Test requires permission to run completion installation tests",
 )


### PR DESCRIPTION
As discussed in https://github.com/fastapi/typer/pull/866#issuecomment-2316421622, introducing a specific env var `_TYPER_RUN_INSTALL_COMPLETION_TESTS` that needs to be set before `--install-completion` tests are run. This env var is set for tests on the CI, but would usually not be set when users run tests locally. This is to ensure no side effects or failing tests happen locally. Fixes #413.

Thanks to @rokbot for raising this issue in #866!