### PR TITLE
🐛 Fix printing HTML from Rich output

### DIFF
--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -1,6 +1,7 @@
 # Extracted and modified from https://github.com/ewels/rich-click
 
 import inspect
+import io
 import sys
 from collections import defaultdict
 from gettext import gettext as _
@@ -717,9 +718,8 @@ def rich_to_html(input_text: str) -> str:
     This function does not provide a full HTML page, but can be used to insert
     HTML-formatted text spans into a markdown file.
     """
-    console = Console(record=True, highlight=False)
+    console = Console(record=True, highlight=False, file=io.StringIO())
 
-    with console.capture():
-        console.print(input_text, overflow="ignore", crop=False)
+    console.print(input_text, overflow="ignore", crop=False)
 
     return console.export_html(inline_styles=True, code_format="{code}").strip()


### PR DESCRIPTION
🐛 Fix printing HTML from Rich output

It seems capturing was not working, I think it did at https://github.com/fastapi/typer/pull/847 because tests were passing, but it seems it's no longer working.

Using `io.StringIO()` seems to be the suggested way in an issue: https://github.com/Textualize/rich/issues/247#issuecomment-678699266