### PR TITLE
📝 Fix minor inconsistencies and typos in tutorial

### DIFF
--- a/docs/tutorial/commands/one-or-multiple.md
+++ b/docs/tutorial/commands/one-or-multiple.md
@@ -129,7 +129,7 @@ Usage: main.py [OPTIONS] COMMAND [ARGS]...
 
   Creates a single user Hiro Hamada.
 
-  In the next version it will create 5 users more.
+  In the next version it will create 5 more users.
 
 Options:
   --install-completion  Install completion for the current shell.

--- a/docs/tutorial/commands/options.md
+++ b/docs/tutorial/commands/options.md
@@ -35,7 +35,7 @@ Commands:
   create
   delete
   delete-all
-  info
+  init
 ```
 
 </div>

--- a/docs/tutorial/first-steps.md
+++ b/docs/tutorial/first-steps.md
@@ -458,7 +458,7 @@ In reality, the parameters that require an order can be made *optional* too. And
 
 ### In **Typer**
 
-To try and make it a bit easier, we'll normally use the words "parameter" or "argument" to refer to Python functions.
+To try and make it a bit easier, we'll normally use the words "parameter" or "argument" to refer to "Python functions parameters" or "Python functions arguments".
 
 We'll use ***CLI argument*** to refer to those *CLI parameters* that depend on the specific order. That are **required** by default.
 

--- a/docs_src/commands/one_or_multiple/tutorial002.py
+++ b/docs_src/commands/one_or_multiple/tutorial002.py
@@ -13,7 +13,7 @@ def callback():
     """
     Creates a single user Hiro Hamada.
 
-    In the next version it will create 5 users more.
+    In the next version it will create 5 more users.
     """
 
 

--- a/tests/test_tutorial/test_commands/test_one_or_multiple/test_tutorial002.py
+++ b/tests/test_tutorial/test_commands/test_one_or_multiple/test_tutorial002.py
@@ -14,7 +14,7 @@ def test_help():
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "Creates a single user Hiro Hamada." in result.output
-    assert "In the next version it will create 5 users more." in result.output
+    assert "In the next version it will create 5 more users." in result.output
     assert "Commands" in result.output
     assert "create" in result.output
 


### PR DESCRIPTION
I think I saw a couple of typos or inconsistencies in the tutorial:
- Grammar error in `commands/one-or-multiple.md`
- Wrong command listed in `command/options.md`
- What looks to be missing words in `first-steps.md` (I doubt a typer "parameter" or "argument" refers to a python function)

Thanks a lot for your work on this great tool. I hope this helps!