### PR TITLE
🐛 Fix escaping in help text when `rich` is installed but not used

### DIFF
--- a/tests/test_rich_markup_mode.py
+++ b/tests/test_rich_markup_mode.py
@@ -20,6 +20,7 @@ def test_rich_markup_mode_none():
     assert "Hello World" in result.stdout
 
     result = runner.invoke(app, ["--help"])
+    assert "ARG  [required]" in result.stdout
     assert all(c not in result.stdout for c in rounded)
 
 

--- a/typer/cli.py
+++ b/typer/cli.py
@@ -301,6 +301,11 @@ def docs(
     if not typer_obj:
         typer.echo("No Typer app found", err=True)
         raise typer.Abort()
+    if hasattr(typer_obj, "rich_markup_mode"):
+        if not hasattr(ctx, "obj") or ctx.obj is None:
+            ctx.ensure_object(dict)
+        if isinstance(ctx.obj, dict):
+            ctx.obj['TYPER_RICH_MARKUP_MODE'] = typer_obj.rich_markup_mode
     click_obj = typer.main.get_command(typer_obj)
     docs = get_docs_for_click(obj=click_obj, ctx=ctx, name=name, title=title)
     clean_docs = f"{docs.strip()}\n"

--- a/typer/core.py
+++ b/typer/core.py
@@ -371,7 +371,10 @@ class TyperArgument(click.core.Argument):
         if extra:
             extra_str = "; ".join(extra)
             extra_str = f"[{extra_str}]"
-            if rich is not None:
+            rich_markup_mode = None
+            if hasattr(ctx, "obj") and isinstance(ctx.obj, dict):
+                rich_markup_mode = ctx.obj.get('TYPER_RICH_MARKUP_MODE', None)
+            if rich is not None and rich_markup_mode == "rich":
                 # This is needed for when we want to export to HTML
                 extra_str = rich.markup.escape(extra_str).strip()
 
@@ -565,7 +568,11 @@ class TyperOption(click.core.Option):
         if extra:
             extra_str = "; ".join(extra)
             extra_str = f"[{extra_str}]"
-            if rich is not None:
+
+            rich_markup_mode = None
+            if hasattr(ctx, "obj") and isinstance(ctx.obj, dict):
+                rich_markup_mode = ctx.obj.get('TYPER_RICH_MARKUP_MODE', None)
+            if rich is not None and rich_markup_mode == "rich":
                 # This is needed for when we want to export to HTML
                 extra_str = rich.markup.escape(extra_str).strip()
 
@@ -690,6 +697,10 @@ class TyperCommand(click.core.Command):
 
     def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         if not rich or self.rich_markup_mode is None:
+            if not hasattr(ctx, "obj") or ctx.obj is None:
+                ctx.ensure_object(dict)
+            if isinstance(ctx.obj, dict):
+                ctx.obj['TYPER_RICH_MARKUP_MODE'] = self.rich_markup_mode
             return super().format_help(ctx, formatter)
         return rich_utils.rich_format_help(
             obj=self,


### PR DESCRIPTION
With PR #847, we implemented functionality to ensure that help descriptions with Rich tags (e.g. `[bold]`) would get rendered properly in Markdown (instead of just showing the "raw" brackets). This uses Rich's functionality from `console.export_html`.

Unfortunately, a problem occurred at the time because meta information like `[required]` looks like Rich tags, but with no known formatting they would just get stripped off by `console.export_html()`. That then meant we had to escape those tags at the point in the code where they're being added to the rest of the help string - this happens in `get_help_record` for both `TyperOption` and `TyperArgument` :
```
if rich is not None:
    # This is needed for when we want to export to HTML
    extra_str = rich.markup.escape(extra_str).strip()

help = f"{help}  {extra_str}" if help else f"{extra_str}"
```

Now, as pointed out in #1058, there's now an issue when the escaping happens if `rich` is installed (triggering the `if` clause in the code above) BUT the Typer app actually has `rich_markup_mode=None`. The help text will in this case show the backslash from the escaping, which is clearly unwanted behaviour.

To remedy, we need to know at the time of escaping what the value is of `rich_markup_mode`. This is not trivial, as `TyperOption` and `TyperArgument` are unaware of this information. And we can't just pass it through from the `Typer` app either, because `get_click_param()` creates empty/default `OptionInfo`/`ArgumentInfo` objects which will lead to default values downstream. I don't see a way to make things work via this route.

Instead, this PR proposes to store a custom value in `ctx.obj`. This object is being passed around anyway, and as far as I understood, `ctx.obj` may be used for these kind of application-specific settings. The code I've written tries to be super careful not to mess up any current usages of this object:

```
    if hasattr(typer_obj, "rich_markup_mode"):
        if not hasattr(ctx, "obj") or ctx.obj is None:
            ctx.ensure_object(dict)
        if isinstance(ctx.obj, dict):
            ctx.obj['TYPER_RICH_MARKUP_MODE'] = typer_obj.rich_markup_mode
```

Then, right before the escaping we can check this value and refrain from escaping if Rich is not enabled.

## WIP

Opening this in draft for now, as there's a few more things I want to check out and test before collecting feedback on this approach.