### PR TITLE
Allow custom styles for commands in help output

### DIFF
--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -488,7 +488,7 @@ def _print_commands_panel(
     # Define formatting in first column, as commands don't match highlighter
     # regex
     commands_table.add_column(
-        style="bold cyan",
+        style=STYLE_OPTION,
         no_wrap=True,
         width=cmd_len,
     )


### PR DESCRIPTION
This PR makes a small tweak to the command highlighting in help output to use the global `STYLE_OPTION` instead of being hardcoded as `bold cyan`:

![image](https://github.com/user-attachments/assets/9af43759-4128-4fbe-a207-54188e073182)

This allows users to more easily customize colors in their help output.