### PR TITLE
adding llms-txt-action to build-docs gha

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Build Docs
         run: python ./scripts/docs.py build
       - name: Generate llms.txt, md files.
-        uses: demodrive-ai/llms-txt-action@7a16ba5e614d6f05e8d5b778feaafacef0b56555
+        uses: demodrive-ai/llms-txt-action@8c352054bffa7689cd507dc2a577121ac23cb0dd
       - uses: actions/upload-artifact@v4
         with:
           name: docs-site

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Build Docs
         run: python ./scripts/docs.py build
       - name: Generate llms.txt, md files.
-        uses: demodrive-ai/llms-txt-action@0.1.0
+        uses: demodrive-ai/llms-txt-action@7a16ba5e614d6f05e8d5b778feaafacef0b56555
       - uses: actions/upload-artifact@v4
         with:
           name: docs-site

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -80,6 +80,8 @@ jobs:
         run: python ./scripts/docs.py verify-readme
       - name: Build Docs
         run: python ./scripts/docs.py build
+      - name: Generate llms.txt, md files.
+        uses: demodrive-ai/llms-txt-action@0.1.0
       - uses: actions/upload-artifact@v4
         with:
           name: docs-site


### PR DESCRIPTION
This PR adds an open-source action to generate necessary llms files to the docs as per the standard.

- Added `demodrive-ai/llms-txt-action@v1` action
- Added `--dirty` flag in gh-deploy to keep the generated files.
