### PR TITLE
:sparkles: Add support for  typing_extensions.Doc (PEP 727)?

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,11 +200,3 @@ known-first-party = ["reigns", "towns", "lands", "items", "users"]
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true
-
-[tool.uv.sources]
-typer = { workspace = true }
-
-[dependency-groups]
-dev = [
-    "typer",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,3 +200,11 @@ known-first-party = ["reigns", "towns", "lands", "items", "users"]
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true
+
+[tool.uv.sources]
+typer = { workspace = true }
+
+[dependency-groups]
+dev = [
+    "typer",
+]

--- a/tests/test_ambiguous_params.py
+++ b/tests/test_ambiguous_params.py
@@ -8,7 +8,7 @@ from typer.utils import (
     MultipleTyperAnnotationsError,
     _split_annotation_from_typer_annotations,
 )
-from typing_extensions import Annotated
+from typing_extensions import Annotated, Doc
 
 runner = CliRunner()
 
@@ -17,10 +17,19 @@ def test_split_annotations_from_typer_annotations_simple():
     # Simple sanity check that this utility works. If this isn't working on a given
     # python version, then no other tests for Annotated will work.
     given = Annotated[str, typer.Argument()]
-    base, typer_annotations = _split_annotation_from_typer_annotations(given)
+    base, typer_annotations, other_annotations = _split_annotation_from_typer_annotations(given)
     assert base is str
     # No equality check on the param types. Checking the length is sufficient.
     assert len(typer_annotations) == 1
+    assert len(other_annotations) == 0
+
+def test_split_other_annotations_from_typer_annotations():
+    given = Annotated[str, typer.Argument(), Doc("doc help")]
+    base, typer_annotations, other_annotations = _split_annotation_from_typer_annotations(given)
+    assert base is str
+    assert len(typer_annotations) == 1
+    assert len(other_annotations) == 1
+    assert isinstance(other_annotations[0], Doc)
 
 
 def test_forbid_default_value_in_annotated_argument():

--- a/tests/test_ambiguous_params.py
+++ b/tests/test_ambiguous_params.py
@@ -17,15 +17,20 @@ def test_split_annotations_from_typer_annotations_simple():
     # Simple sanity check that this utility works. If this isn't working on a given
     # python version, then no other tests for Annotated will work.
     given = Annotated[str, typer.Argument()]
-    base, typer_annotations, other_annotations = _split_annotation_from_typer_annotations(given)
+    base, typer_annotations, other_annotations = (
+        _split_annotation_from_typer_annotations(given)
+    )
     assert base is str
     # No equality check on the param types. Checking the length is sufficient.
     assert len(typer_annotations) == 1
     assert len(other_annotations) == 0
 
+
 def test_split_other_annotations_from_typer_annotations():
     given = Annotated[str, typer.Argument(), Doc("doc help")]
-    base, typer_annotations, other_annotations = _split_annotation_from_typer_annotations(given)
+    base, typer_annotations, other_annotations = (
+        _split_annotation_from_typer_annotations(given)
+    )
     assert base is str
     assert len(typer_annotations) == 1
     assert len(other_annotations) == 1

--- a/tests/test_parameter_help.py
+++ b/tests/test_parameter_help.py
@@ -1,12 +1,11 @@
 from typing import Annotated
-from typing_extensions import Doc
-import pytest
 
+import pytest
 import typer
 import typer.completion
+from typer import Argument, Option
 from typer.testing import CliRunner
-from typer import Option, Argument
-
+from typing_extensions import Doc
 
 
 @pytest.fixture
@@ -17,16 +16,8 @@ def runner():
 @pytest.mark.parametrize(
     "doc,parameter,expected",
     [
-        (
-            Doc("doc only help"),
-            None,
-            "doc only help"
-        ),
-        (
-            None,
-            Argument(help="argument only help"),
-            "argument only help"
-        ),
+        (Doc("doc only help"), None, "doc only help"),
+        (None, Argument(help="argument only help"), "argument only help"),
         (
             Doc("doc help should appear"),
             Argument(),
@@ -37,11 +28,7 @@ def runner():
             Argument(help="argument help has priority"),
             "argument help has priority",
         ),
-        (
-            None,
-            Option(help="option only help"),
-            "option only help"
-        ),
+        (None, Option(help="option only help"), "option only help"),
         (
             Doc("this help should not appear"),
             Option(help="option help has priority"),

--- a/tests/test_parameter_help.py
+++ b/tests/test_parameter_help.py
@@ -1,0 +1,65 @@
+from typing import Annotated
+from typing_extensions import Doc
+import pytest
+
+import typer
+import typer.completion
+from typer.testing import CliRunner
+from typer import Option, Argument
+
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.mark.parametrize(
+    "doc,parameter,expected",
+    [
+        (
+            Doc("doc only help"),
+            None,
+            "doc only help"
+        ),
+        (
+            None,
+            Argument(help="argument only help"),
+            "argument only help"
+        ),
+        (
+            Doc("doc help should appear"),
+            Argument(),
+            "doc help should appear",
+        ),
+        (
+            Doc("this help should not appear"),
+            Argument(help="argument help has priority"),
+            "argument help has priority",
+        ),
+        (
+            None,
+            Option(help="option only help"),
+            "option only help"
+        ),
+        (
+            Doc("this help should not appear"),
+            Option(help="option help has priority"),
+            "option help has priority",
+        ),
+        (
+            Doc("doc help should appear"),
+            Option(),
+            "doc help should appear",
+        ),
+    ],
+)
+def test_doc_help(runner, doc, parameter, expected):
+    app = typer.Typer()
+
+    @app.command()
+    def main(arg: Annotated[str, doc, parameter]):
+        print(f"Hello {arg}")
+
+    result = runner.invoke(app, ["--help"])
+    assert expected in result.stdout

--- a/tests/test_parameter_help.py
+++ b/tests/test_parameter_help.py
@@ -8,11 +8,6 @@ from typer.testing import CliRunner
 from typing_extensions import Doc
 
 
-@pytest.fixture
-def runner():
-    return CliRunner()
-
-
 @pytest.mark.parametrize(
     "doc,parameter,expected",
     [
@@ -41,12 +36,13 @@ def runner():
         ),
     ],
 )
-def test_doc_help(runner, doc, parameter, expected):
+def test_doc_help(doc, parameter, expected):
     app = typer.Typer()
 
     @app.command()
     def main(arg: Annotated[str, doc, parameter]):
         print(f"Hello {arg}")
 
+    runner = CliRunner()
     result = runner.invoke(app, ["--help"])
     assert expected in result.stdout

--- a/typer/main.py
+++ b/typer/main.py
@@ -12,11 +12,10 @@ from pathlib import Path
 from traceback import FrameSummary, StackSummary
 from types import TracebackType
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
-from typing_extensions import Doc
 from uuid import UUID
 
 import click
-from typing_extensions import get_args, get_origin
+from typing_extensions import Doc, get_args, get_origin
 
 from ._typing import is_union
 from .completion import get_completion_inspect_parameters
@@ -47,7 +46,7 @@ from .models import (
     Required,
     TyperInfo,
 )
-from .utils import get_params_from_function, MultipleDocAnnotationsError
+from .utils import MultipleDocAnnotationsError, get_params_from_function
 
 try:
     import rich

--- a/typer/main.py
+++ b/typer/main.py
@@ -827,12 +827,12 @@ def get_click_param(
             for annotation in param.other_annotations
             if isinstance(annotation, Doc)
         ]
+        if len(doc_annotations) > 1:
+            raise MultipleDocAnnotationsError(param.name)
         if len(doc_annotations) == 1:
             doc_help = doc_annotations[0].documentation if doc_annotations else None
             if not getattr(parameter_info, "help", None):
                 parameter_info.help = doc_help
-        if len(doc_annotations) > 1:
-            raise MultipleDocAnnotationsError(param.name)
     annotation: Any
     if param.annotation is not param.empty:
         annotation = param.annotation

--- a/typer/models.py
+++ b/typer/models.py
@@ -514,10 +514,12 @@ class ParamMeta:
         name: str,
         default: Any = inspect.Parameter.empty,
         annotation: Any = inspect.Parameter.empty,
+        other_annotations: List[Any] = None,
     ) -> None:
         self.name = name
         self.default = default
         self.annotation = annotation
+        self.other_annotations = other_annotations
 
 
 class DeveloperExceptionConfig:

--- a/typer/utils.py
+++ b/typer/utils.py
@@ -174,7 +174,6 @@ def get_params_from_function(func: Callable[..., Any]) -> Dict[str, ParamMeta]:
                 parameter_info.default = ...
 
             # Forbid `my_param: Annotated[str, Argument('some-default')]`
-            import pdb; pdb.set_trace()
             if parameter_info.default is not ...:
                 raise AnnotatedParamWithDefaultValueError(
                     param_type=type(parameter_info),

--- a/typer/utils.py
+++ b/typer/utils.py
@@ -3,7 +3,7 @@ import sys
 from copy import copy
 from typing import Any, Callable, Dict, List, Tuple, Type, cast
 
-from typing_extensions import Annotated, get_args, get_origin, get_type_hints, Doc
+from typing_extensions import Annotated, get_args, get_origin, get_type_hints
 
 from .models import ArgumentInfo, OptionInfo, ParameterInfo, ParamMeta
 
@@ -137,8 +137,10 @@ def get_params_from_function(func: Callable[..., Any]) -> Dict[str, ParamMeta]:
     type_hints = get_type_hints(func)
     params = {}
     for param in signature.parameters.values():
-        annotation, typer_annotations, other_annotations = _split_annotation_from_typer_annotations(
-            param.annotation,
+        annotation, typer_annotations, other_annotations = (
+            _split_annotation_from_typer_annotations(
+                param.annotation,
+            )
         )
         if len(typer_annotations) > 1:
             raise MultipleTyperAnnotationsError(param.name)

--- a/typer/utils.py
+++ b/typer/utils.py
@@ -105,11 +105,11 @@ class DefaultFactoryAndDefaultValueError(Exception):
         )
 
 
-def _split_annotation_from_doc_and_typer_annotations(
+def _split_annotation_from_typer_annotations(
     base_annotation: Type[Any],
 ) -> Tuple[Type[Any], List[ParameterInfo]]:
     if get_origin(base_annotation) is not Annotated:
-        return base_annotation, []
+        return base_annotation, [], []
     base_annotation, *other_annotations = get_args(base_annotation)
     typer_annotations = [
         annotation
@@ -137,7 +137,7 @@ def get_params_from_function(func: Callable[..., Any]) -> Dict[str, ParamMeta]:
     type_hints = get_type_hints(func)
     params = {}
     for param in signature.parameters.values():
-        annotation, typer_annotations, other_annotations = _split_annotation_from_doc_and_typer_annotations(
+        annotation, typer_annotations, other_annotations = _split_annotation_from_typer_annotations(
             param.annotation,
         )
         if len(typer_annotations) > 1:
@@ -174,6 +174,7 @@ def get_params_from_function(func: Callable[..., Any]) -> Dict[str, ParamMeta]:
                 parameter_info.default = ...
 
             # Forbid `my_param: Annotated[str, Argument('some-default')]`
+            import pdb; pdb.set_trace()
             if parameter_info.default is not ...:
                 raise AnnotatedParamWithDefaultValueError(
                     param_type=type(parameter_info),

--- a/typer/utils.py
+++ b/typer/utils.py
@@ -144,6 +144,7 @@ def get_params_from_function(func: Callable[..., Any]) -> Dict[str, ParamMeta]:
         )
         if len(typer_annotations) > 1:
             raise MultipleTyperAnnotationsError(param.name)
+
         default = param.default
         if typer_annotations:
             # It's something like `my_param: Annotated[str, Argument()]`
@@ -156,6 +157,8 @@ def get_params_from_function(func: Callable[..., Any]) -> Dict[str, ParamMeta]:
                     annotated_param_type=type(parameter_info),
                     default_param_type=type(param.default),
                 )
+
+            parameter_info = copy(parameter_info)
 
             # When used as a default, `Option` takes a default value and option names
             # as positional arguments:


### PR DESCRIPTION
I've added tests but not yet documentation. I can add that if this feature has a chance of acceptance.

I've opened a question for this feature here: https://github.com/fastapi/typer/discussions/1110