### PR TITLE
💚 Fix test matrix for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - opened
       - synchronize
   schedule:
-    # cron every week on  monday
+    # cron every week on monday
     - cron: "0 0 * * 1"
 
 env:
@@ -22,7 +22,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ "3.12" ]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             python-version: "3.7"
           - os: macos-latest
             python-version: "3.8"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - opened
       - synchronize
   schedule:
-    # cron every week on monday
+    # cron every week on  monday
     - cron: "0 0 * * 1"
 
 env:


### PR DESCRIPTION
Limit the ubuntu version in the test suite to `22.04`, which still supports Python 3.7 while the current `ubuntu-latest` image doesn't anymore.