### PR TITLE
🐛 Fix default value handling in parameter help extraction when rich is installed

### DIFF
--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -285,9 +285,9 @@ def _get_parameter_help(
     # Default value
     # This uses Typer's specific param._get_default_string
     if isinstance(param, (TyperOption, TyperArgument)):
-        if param.show_default:
-            show_default_is_str = isinstance(param.show_default, str)
-            default_value = param._extract_default_help_str(ctx=ctx)
+        default_value = param._extract_default_help_str(ctx=ctx)
+        show_default_is_str = isinstance(param.show_default, str)
+        if show_default_is_str or (default_value is not None and (param.show_default or ctx.show_default)):
             default_str = param._get_default_string(
                 ctx=ctx,
                 show_default_is_str=show_default_is_str,


### PR DESCRIPTION
Fixes #465

Improves consistency with `Typer(rich_markup_mode=None)` ([TyperArgument.get_help_record](https://github.com/fastapi/typer/blob/f1108450db352bf9a5677312fdfe1f3766d0e0bb/typer/core.py#L351-L368)), which does not print the default value if it is None.