### PR TITLE
Fix arg parameter of autocompletion

### DIFF
--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -176,7 +176,7 @@ def test_completion_untyped_parameters():
         },
     )
     assert "info name is: completion_no_types.py" in result.stderr
-    assert "args is: []" in result.stderr
+    assert "args is: ['--name', 'Sebastian', '--name']" in result.stderr
     assert "incomplete is: Ca" in result.stderr
     assert '"Camila":"The reader of books."' in result.stdout
     assert '"Carlos":"The writer of scripts."' in result.stdout
@@ -202,7 +202,7 @@ def test_completion_untyped_parameters_different_order_correct_names():
         },
     )
     assert "info name is: completion_no_types_order.py" in result.stderr
-    assert "args is: []" in result.stderr
+    assert "args is: ['--name', 'Sebastian', '--name']" in result.stderr
     assert "incomplete is: Ca" in result.stderr
     assert '"Camila":"The reader of books."' in result.stdout
     assert '"Carlos":"The writer of scripts."' in result.stdout

--- a/tests/test_tutorial/test_options_autocompletion/test_tutorial008.py
+++ b/tests/test_tutorial/test_options_autocompletion/test_tutorial008.py
@@ -23,7 +23,7 @@ def test_completion():
     assert '"Camila":"The reader of books."' in result.stdout
     assert '"Carlos":"The writer of scripts."' in result.stdout
     assert '"Sebastian":"The type hints guy."' in result.stdout
-    assert "[]" in result.stderr
+    assert "--name" in result.stderr
 
 
 def test_1():

--- a/tests/test_tutorial/test_options_autocompletion/test_tutorial008_an.py
+++ b/tests/test_tutorial/test_options_autocompletion/test_tutorial008_an.py
@@ -23,7 +23,7 @@ def test_completion():
     assert '"Camila":"The reader of books."' in result.stdout
     assert '"Carlos":"The writer of scripts."' in result.stdout
     assert '"Sebastian":"The type hints guy."' in result.stdout
-    assert "[]" in result.stderr
+    assert "--name" in result.stderr
 
 
 def test_1():

--- a/tests/test_tutorial/test_options_autocompletion/test_tutorial009.py
+++ b/tests/test_tutorial/test_options_autocompletion/test_tutorial009.py
@@ -23,7 +23,7 @@ def test_completion():
     assert '"Camila":"The reader of books."' in result.stdout
     assert '"Carlos":"The writer of scripts."' in result.stdout
     assert '"Sebastian":"The type hints guy."' not in result.stdout
-    assert "[]" in result.stderr
+    assert "--name Sebastian --name" in result.stderr
 
 
 def test_1():

--- a/tests/test_tutorial/test_options_autocompletion/test_tutorial009.py
+++ b/tests/test_tutorial/test_options_autocompletion/test_tutorial009.py
@@ -23,7 +23,7 @@ def test_completion():
     assert '"Camila":"The reader of books."' in result.stdout
     assert '"Carlos":"The writer of scripts."' in result.stdout
     assert '"Sebastian":"The type hints guy."' not in result.stdout
-    assert "--name Sebastian --name" in result.stderr
+    assert "['--name', 'Sebastian', '--name']" in result.stderr
 
 
 def test_1():

--- a/tests/test_tutorial/test_options_autocompletion/test_tutorial009_an.py
+++ b/tests/test_tutorial/test_options_autocompletion/test_tutorial009_an.py
@@ -23,7 +23,7 @@ def test_completion():
     assert '"Camila":"The reader of books."' in result.stdout
     assert '"Carlos":"The writer of scripts."' in result.stdout
     assert '"Sebastian":"The type hints guy."' not in result.stdout
-    assert "[]" in result.stderr
+    assert "--name Sebastian --name" in result.stderr
 
 
 def test_1():

--- a/tests/test_tutorial/test_options_autocompletion/test_tutorial009_an.py
+++ b/tests/test_tutorial/test_options_autocompletion/test_tutorial009_an.py
@@ -23,7 +23,7 @@ def test_completion():
     assert '"Camila":"The reader of books."' in result.stdout
     assert '"Carlos":"The writer of scripts."' in result.stdout
     assert '"Sebastian":"The type hints guy."' not in result.stdout
-    assert "--name Sebastian --name" in result.stderr
+    assert "['--name', 'Sebastian', '--name']" in result.stderr
 
 
 def test_1():

--- a/typer/_completion_classes.py
+++ b/typer/_completion_classes.py
@@ -42,6 +42,10 @@ class BashComplete(click.shell_completion.BashComplete):
         except IndexError:
             incomplete = ""
 
+        obj = self.ctx_args.setdefault("obj", {})
+        if isinstance(obj, dict):
+            obj.setdefault("args", args)
+
         return args, incomplete
 
     def format_completion(self, item: click.shell_completion.CompletionItem) -> str:
@@ -77,6 +81,11 @@ class ZshComplete(click.shell_completion.ZshComplete):
             args = args[:-1]
         else:
             incomplete = ""
+
+        obj = self.ctx_args.setdefault("obj", {})
+        if isinstance(obj, dict):
+            obj.setdefault("args", args)
+
         return args, incomplete
 
     def format_completion(self, item: click.shell_completion.CompletionItem) -> str:
@@ -128,6 +137,11 @@ class FishComplete(click.shell_completion.FishComplete):
             args = args[:-1]
         else:
             incomplete = ""
+
+        obj = self.ctx_args.setdefault("obj", {})
+        if isinstance(obj, dict):
+            obj.setdefault("args", args)
+
         return args, incomplete
 
     def format_completion(self, item: click.shell_completion.CompletionItem) -> str:
@@ -177,6 +191,9 @@ class PowerShellComplete(click.shell_completion.ShellComplete):
         incomplete = os.getenv("_TYPER_COMPLETE_WORD_TO_COMPLETE", "")
         cwords = click.parser.split_arg_string(completion_args)
         args = cwords[1:-1] if incomplete else cwords[1:]
+        obj = self.ctx_args.setdefault("obj", {})
+        if isinstance(obj, dict):
+            obj.setdefault("args", args)
         return args, incomplete
 
     def format_completion(self, item: click.shell_completion.CompletionItem) -> str:

--- a/typer/main.py
+++ b/typer/main.py
@@ -1059,7 +1059,8 @@ def get_param_completion(
         if ctx_name:
             use_params[ctx_name] = ctx
         if args_name:
-            use_params[args_name] = args
+            obj = ctx.obj or {}
+            use_params[args_name] = obj.get("args", []) if isinstance(obj, dict) else []
         if incomplete_name:
             use_params[incomplete_name] = incomplete
         return callback(**use_params)


### PR DESCRIPTION
Separated from #1006 

Bug documented in #1133 

One note on the implementation. Because the CLI options during an autocompletion run are passed through shell-specific mechanisms (usually environment variables) and are not available in sys.args we have to resort to adding this information to the context in the completer classes. Click provides a mechanism to do this using ctx_args and the "obj" parameter. Obj is seldom used, but it can be anything per the click docs. Right now I do not believe the click code path sets it to anything. This PR sets it to a dictionary if it isn't already and if it is dictionary it sets the args key to be the arguments passed by the shell specific mechanism. This would be brittle to obj being set somewhere upstream to anything but a dictionary. I think this is unlikely to happen, but if it does it will not brick the code, it'll just revert to the current behavior (empty list) and the CI will fail.