### PR TITLE
✏️ Fix small typos in the tutorial documentation

### DIFF
--- a/docs/tutorial/options-autocompletion.md
+++ b/docs/tutorial/options-autocompletion.md
@@ -165,7 +165,7 @@ That simplifies our code a bit and works the same.
 
 /// tip
 
-If all the `yield` part seems complex for you, don't worry, you can just use the version with the `list` above.
+If the `yield` part seems complex for you, don't worry, you can just use the version with the `list` above.
 
 In the end, that's just to save us a couple of lines of code.
 

--- a/docs/tutorial/options-autocompletion.md
+++ b/docs/tutorial/options-autocompletion.md
@@ -10,7 +10,7 @@ But you can also provide auto completion for the **values** of *CLI options* and
 
 Before checking how to provide custom completions, let's check again how it works.
 
-After installing completion for your own Python package (or using the `typer` command), when you use your CLI program and start adding a *CLI option* with `--` an then hit <kbd>TAB</kbd>, your shell will show you the available *CLI options* (the same for *CLI arguments*, etc).
+After installing completion for your own Python package (or using the `typer` command), when you use your CLI program and start adding a *CLI option* with `--` and then hit <kbd>TAB</kbd>, your shell will show you the available *CLI options* (the same for *CLI arguments*, etc).
 
 To check it quickly without creating a new Python package, use the `typer` command.
 

--- a/docs/tutorial/options/callback-and-context.md
+++ b/docs/tutorial/options/callback-and-context.md
@@ -43,7 +43,7 @@ There's something to be aware of with callbacks and completion that requires som
 
 But first let's just use completion in your shell (Bash, Zsh, Fish, or PowerShell).
 
-After installing completion (for your own Python package), when you use your CLI program and start adding a *CLI option* with `--` an then hit <kbd>TAB</kbd>, your shell will show you the available *CLI options* (the same for *CLI arguments*, etc).
+After installing completion (for your own Python package), when you use your CLI program and start adding a *CLI option* with `--` and then hit <kbd>TAB</kbd>, your shell will show you the available *CLI options* (the same for *CLI arguments*, etc).
 
 To check it quickly with the previous script use the `typer` command:
 


### PR DESCRIPTION
- Fixed the same typo twice
- Removed an unnecessary word which was hindering interpretability of the sentence