### PR TITLE
🔧 Ignore .DS_Store for people browsing files on Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ htmlcov
 coverage.xml
 .coverage*
 .cache
+
+# ignore for folks browsing directories on a Mac
+.DS_Store


### PR DESCRIPTION
Add `.DS_Store` to `.gitignore`. 

Unfortunately, Mac's litter the file system with `.DS_Store` files when browsing the directories. The most frequent occurrence is when looking for code coverage results files. This change ignores them to avoid committing them.