### PR TITLE
🔨  Add --showlocals to test.sh

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,4 +10,4 @@ export _TYPER_FORCE_DISABLE_TERMINAL=1
 # Run autocompletion install tests in the CI
 export _TYPER_RUN_INSTALL_COMPLETION_TESTS=1
 # It seems xdist-pytest ensures modified sys.path to import relative modules in examples keeps working
-pytest --cov --cov-report=term-missing -o console_output_style=progress --numprocesses=auto ${@}
+pytest --cov --cov-report=term-missing -o console_output_style=progress --showlocals --numprocesses=auto ${@}


### PR DESCRIPTION
When tests fail, this provides more debug information. Having the extra debug is particularly useful when working in different  environments than your local setup (e.g. different Python versions in the CI pipeline).