### PR TITLE
📌 Pin Click to < 8.2, compatibility for Click >= 8.2 will be added in a future version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
-    "click >= 8.0.0",
+    "click >= 8.0.0,<8.2",
     "typing-extensions >= 3.7.4.3",
 ]
 readme = "README.md"


### PR DESCRIPTION
Compatibility for Click >= 8.2 is worked on here: https://github.com/fastapi/typer/pull/1222 , but there are a couple of unsolved issues there still.

So this pin will solve current apps for now, and a future release will have compatibility with the latest Click.