### PR TITLE
fix(core): Ensure exit code 0 when no_args_is_help shows help

### DIFF
--- a/typer/core.py
+++ b/typer/core.py
@@ -208,6 +208,8 @@ def _main(
             raise click.Abort() from e
         except KeyboardInterrupt as e:
             raise click.exceptions.Exit(130) from e
+        except click.exceptions.NoArgsIsHelpError as e:
+            raise click.exceptions.Exit(0) from e
         except click.ClickException as e:
             if not standalone_mode:
                 raise


### PR DESCRIPTION
When 'no_args_is_help' is True and no arguments are provided to a Typer application, the help message is displayed. However, an additional empty error panel also currently appears, and the application exits with status code 2. This issue affects applications using Click version 8.2.0 or later.

The root cause is a change in Click (pallets/click@d8763b93) where Command.parse_args now raises click.exceptions.NoArgsIsHelpError when no_args_is_help is true and no arguments are given. Previously, Click would print help and call ctx.exit() directly within parse_args.

Typer's generic except click.ClickException as e: block in TyperGroup._main (via typer.core.TyperCommand._main) catches this NoArgsIsHelpError. The subsequent call to rich_utils.rich_format_error(e) (or e.show() if Rich is not used) results in the help message being displayed. This is because NoArgsIsHelpError is a subclass of click.UsageError, and UsageError.show() prints ctx.get_help(). However, this process also leads to an attempt to format a non-existent specific error message (as NoArgsIsHelpError.format_message() is empty), causing the blank error panel. Finally, sys.exit(e.exit_code) uses the UsageError's exit code of 2.

This commit addresses the issue by introducing a dedicated exception handler for click.exceptions.NoArgsIsHelpError before the generic click.ClickException handler in typer.core.TyperGroup._main. This new handler catches NoArgsIsHelpError and then raises click.exceptions.Exit(0).

This ensures that after the help message is displayed, the application exits cleanly with status code 0 and without displaying the erroneous empty error panel, aligning with the intended behavior of no_args_is_help.