### PR TITLE
fix(core): Ensure exit code 0 when no_args_is_help shows help

### DIFF
--- a/tests/test_no_args_help_exit_code.py
+++ b/tests/test_no_args_help_exit_code.py
@@ -1,0 +1,34 @@
+import typer
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_no_args_is_help_exit_code_zero():
+    app = typer.Typer(no_args_is_help=True)
+
+    @app.command()
+    def foo():
+        """A foo command"""
+        print("foo!")
+
+    @app.command()
+    def bar():
+        """A bar command"""
+        print("bar!")
+
+    result = runner.invoke(app, [])
+    # It should show help and exit code should be 0
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+    assert "foo" in result.output
+    assert "bar" in result.output
+
+    # Also check that actual commands still work
+    result_foo = runner.invoke(app, ["foo"])
+    assert result_foo.exit_code == 0
+    assert "foo!" in result_foo.output
+
+    result_bar = runner.invoke(app, ["bar"])
+    assert result_bar.exit_code == 0
+    assert "bar!" in result_bar.output

--- a/typer/core.py
+++ b/typer/core.py
@@ -25,6 +25,7 @@ import click.parser
 import click.shell_completion
 import click.types
 import click.utils
+from click.exceptions import NoArgsIsHelpError
 
 from ._typing import Literal
 
@@ -208,6 +209,8 @@ def _main(
             raise click.Abort() from e
         except KeyboardInterrupt as e:
             raise click.exceptions.Exit(130) from e
+        except NoArgsIsHelpError as e:
+            raise click.exceptions.Exit(0) from e
         except click.ClickException as e:
             if not standalone_mode:
                 raise


### PR DESCRIPTION
When `no_args_is_help` is True and no arguments are provided to a Typer application, the help message is displayed. However, an additional empty error panel also currently appears, and the application exits with status code 2. This issue affects applications using Click version 8.2.0 or later.

The root cause is a change in Click ([pallets/click@d8763b93](https://github.com/pallets/click/commit/d8763b93)) where `Command.parse_args` now raises `click.exceptions.NoArgsIsHelpError` when `no_args_is_help` is true and no arguments are given. Previously, Click would print help and call `ctx.exit()` directly within `parse_args`.

Typer's generic `except click.ClickException as e:` block in `core.py._main` catches this `NoArgsIsHelpError`. The subsequent call to `rich_utils.rich_format_error(e)` (or `e.show()` if Rich is not used) results in the help message being displayed. This is because `NoArgsIsHelpError` is a subclass of `click.UsageError`, and `UsageError.show()` prints `ctx.get_help()`. However, this process also leads to an attempt to format a non-existent specific error message (as `NoArgsIsHelpError.format_message()` is empty), causing the blank error panel. Finally, `sys.exit(e.exit_code)` uses the `UsageError`'s exit code of 2.

This commit addresses the issue by checking if the `click.ClickException` is of instance `NoArgsIsHelpError` and then raising `click.exceptions.Exit(0)`

This ensures that after the help message is displayed, the application exits cleanly with status code 0 and without displaying the erroneous empty error panel, aligning with the intended behavior of `no_args_is_help`.

Based on discussion from [[https://github.com/fastapi/typer/pull/1240]]