### PR TITLE
Fix the output for no_args_is_help=True

### DIFF
--- a/typer/core.py
+++ b/typer/core.py
@@ -20,6 +20,7 @@ from typing import (
 
 import click
 import click.core
+from click.exceptions import NoArgsIsHelpError
 import click.formatting
 import click.parser
 import click.shell_completion
@@ -208,6 +209,8 @@ def _main(
             raise click.Abort() from e
         except KeyboardInterrupt as e:
             raise click.exceptions.Exit(130) from e
+        except NoArgsIsHelpError:
+            click.echo()
         except click.ClickException as e:
             if not standalone_mode:
                 raise


### PR DESCRIPTION
Since typer 0.16.0, running a CLI with the no_args_is_help feature enabled displays an error block. The patch from the PR suppresses the duplicate `Usage:` info and the `Error` output block, in case the processed exception is a NoArgsIsHelperror.

**Example with invalid output (based on the `no_args_is_help` example code)**

<img width="724" height="332" alt="image" src="https://github.com/user-attachments/assets/39d73157-06b0-4ea7-a2e9-00396647efcc" />


**Output with this patch applied:**

<img width="722" height="261" alt="image" src="https://github.com/user-attachments/assets/678fba2a-1ab9-4237-bd03-29c41f4fd8bd" />
