### PR TITLE
Treat keyword only parameters as OptionInfo even without default

### DIFF
--- a/tests/test_ambiguous_params.py
+++ b/tests/test_ambiguous_params.py
@@ -229,3 +229,21 @@ def test_forbid_default_and_default_factory_with_default_param(param, param_info
 )
 def test_error_rendering(error, message):
     assert str(error) == message
+
+
+def test_keyword_only_without_default_becomes_option():
+    app = typer.Typer()
+
+    @app.command()
+    def cmd(*, my_param):
+        print(my_param)
+
+    # Check that it works with the keyword
+    result = runner.invoke(app, ["--my-param", "hello"])
+    assert result.exit_code == 0, result.output
+    assert "hello" in result.output
+
+    # Check that it fails without the keyword
+    result = runner.invoke(app, ["hello"])
+    assert result.exit_code != 0, result.output
+    assert "Missing option" in result.output, result.output

--- a/typer/main.py
+++ b/typer/main.py
@@ -823,7 +823,10 @@ def get_click_param(
             default_value = parameter_info.default
     elif param.default == Required or param.default is param.empty:
         required = True
-        parameter_info = ArgumentInfo()
+        if param.kind == inspect.Parameter.KEYWORD_ONLY:
+            parameter_info = OptionInfo()
+        else:
+            parameter_info = ArgumentInfo()
     else:
         default_value = param.default
         parameter_info = OptionInfo()

--- a/typer/models.py
+++ b/typer/models.py
@@ -514,10 +514,12 @@ class ParamMeta:
         name: str,
         default: Any = inspect.Parameter.empty,
         annotation: Any = inspect.Parameter.empty,
+        kind: inspect.Parameter = inspect.Parameter.POSITIONAL_OR_KEYWORD,
     ) -> None:
         self.name = name
         self.default = default
         self.annotation = annotation
+        self.kind = kind
 
 
 class DeveloperExceptionConfig:

--- a/typer/utils.py
+++ b/typer/utils.py
@@ -185,6 +185,6 @@ def get_params_from_function(func: Callable[..., Any]) -> Dict[str, ParamMeta]:
             default = parameter_info
 
         params[param.name] = ParamMeta(
-            name=param.name, default=default, annotation=annotation
+            name=param.name, default=default, annotation=annotation, kind=param.kind
         )
     return params


### PR DESCRIPTION
Reviving #270 to make Typer treat keyword only parameters as options even when they dont have a default.

E.g. 
```python
@app.command()
def my_command(*, my_param):
     pass
```

Will now result in the following CLI with a flag instead of positional parameter:
`python my_module --my-param value`


Supports #269