### PR TITLE
📝 Clarify single-command vs multi-command behaviour in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Goodbye Ms. Camila. Have a good day.
 
 </div>
 
-**Note**: If your app only has one command, the command name is **omitted** in usage: `python main.py Camila`. However, when there are multiple commands, you must **explicitly include the command name**: `python main.py hello Camila`. See [One or Multiple Commands](https://typer.tiangolo.com/tutorial/commands/one-or-multiple/) for more details.
+**Note**: If your app only has one command, by default the command name is **omitted** in usage: `python main.py Camila`. However, when there are multiple commands, you must **explicitly include the command name**: `python main.py hello Camila`. See [One or Multiple Commands](https://typer.tiangolo.com/tutorial/commands/one-or-multiple/) for more details.
 
 ### Recap
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ Goodbye Ms. Camila. Have a good day.
 
 </div>
 
+**Note**: If your app only has one command, the command name is **omitted** in usage: `python main.py Camila`. However, when there are multiple commands, you must **explicitly include the command name**: `python main.py hello Camila`. See [One or Multiple Commands](https://typer.tiangolo.com/tutorial/commands/one-or-multiple/) for more details.
+
 ### Recap
 
 In summary, you declare **once** the types of parameters (*CLI arguments* and *CLI options*) as function parameters.

--- a/docs/index.md
+++ b/docs/index.md
@@ -324,6 +324,8 @@ Goodbye Ms. Camila. Have a good day.
 
 </div>
 
+**Note**: If your app only has one command, the command name is **omitted** in usage: `python main.py Camila`. However, when there are multiple commands, you must **explicitly include the command name**: `python main.py hello Camila`. See [One or Multiple Commands](https://typer.tiangolo.com/tutorial/commands/one-or-multiple/) for more details.
+
 ### Recap
 
 In summary, you declare **once** the types of parameters (*CLI arguments* and *CLI options*) as function parameters.

--- a/docs/index.md
+++ b/docs/index.md
@@ -324,7 +324,7 @@ Goodbye Ms. Camila. Have a good day.
 
 </div>
 
-**Note**: If your app only has one command, the command name is **omitted** in usage: `python main.py Camila`. However, when there are multiple commands, you must **explicitly include the command name**: `python main.py hello Camila`. See [One or Multiple Commands](https://typer.tiangolo.com/tutorial/commands/one-or-multiple/) for more details.
+**Note**: If your app only has one command, by default the command name is **omitted** in usage: `python main.py Camila`. However, when there are multiple commands, you must **explicitly include the command name**: `python main.py hello Camila`. See [One or Multiple Commands](https://typer.tiangolo.com/tutorial/commands/one-or-multiple/) for more details.
 
 ### Recap
 


### PR DESCRIPTION
This PR adds a note in the README explaining that Typer treats single-command CLIs differently than multi-command CLIs.

This behavior can be surprising for new users (like myself), because calling the command by name (e.g., python cli.py hello Camila) results in an error when only one command is defined — Typer silently expects python cli.py Camila instead.

While this is explained in the full documentation, the README contains a similar example and is often the first place beginners look. A brief clarification here could help save users some confusion — especially those coming from FastAPI, where the number of wrapped functions doesn’t affect how the app is invoked.

Related issues:

#315 - this PR directly addresses confusion raised here.

#445 - is tangentially related in that it also highlights behavioral differences when only one subcommand exists.

I’ve also explored making this behavior configurable (i.e., supporting both styles of invocation), and I’d be happy to help further if there’s interest. But this change is a simple, non-breaking way to surface the existing behavior earlier for new users.

Let me know if you'd prefer the note be placed elsewhere, want to reword it, or would like help drafting a fuller fix later on.