### PR TITLE
✨ Add `module:function` syntax support for typer CLI

### DIFF
--- a/docs/tutorial/typer-command.md
+++ b/docs/tutorial/typer-command.md
@@ -215,12 +215,40 @@ Hello Camila
 
 </div>
 
+### Run a package or module with specified function
+
+You can also specify a function directly using the colon syntax:
+
+<div class="termy">
+
+```console
+$ typer my_package.main:my_function run --name Camila
+
+Hello Camila
+```
+
+</div>
+
+or with the file path
+
+<div class="termy">
+
+```console
+$ typer main.py:my_function run --name Camila
+
+Hello Camila
+```
+
+</div>
+
 ## Options
 
 You can specify one of the following **CLI options**:
 
 * `--app`: the name of the variable with a `Typer()` object to run as the main app.
 * `--func`: the name of the variable with a function that would be used with `typer.run()`.
+
+Alternatively, you can specify the function directly using the syntax `module:function`.
 
 ### Defaults
 

--- a/tests/test_cli/test_multi_func.py
+++ b/tests/test_cli/test_multi_func.py
@@ -85,6 +85,26 @@ def test_script_func_not_function():
     assert "Not a function:" in result.stderr
 
 
+def test_script_colon_not_function():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            "-m",
+            "typer",
+            "tests/assets/cli/multi_func.py:message",
+            "run",
+            "--name",
+            "Camila",
+        ],
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert "Not a function:" in result.stderr
+
+
 def test_script_func():
     result = subprocess.run(
         [
@@ -97,6 +117,44 @@ def test_script_func():
             "--func",
             "say_stuff",
             "tests/assets/cli/multi_func.py",
+            "run",
+        ],
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert "Hello" not in result.stdout
+    assert "Stuff" in result.stdout
+
+
+def test_script_module_colon_func():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            "-m",
+            "typer",
+            "tests.assets.cli.multi_func:say_stuff",
+            "run",
+        ],
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert "Hello" not in result.stdout
+    assert "Stuff" in result.stdout
+
+
+def test_script_file_colon_func():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            "-m",
+            "typer",
+            "tests/assets/cli/multi_func.py:say_stuff",
             "run",
         ],
         capture_output=True,

--- a/typer/cli.py
+++ b/typer/cli.py
@@ -43,6 +43,10 @@ state = State()
 def maybe_update_state(ctx: click.Context) -> None:
     path_or_module = ctx.params.get("path_or_module")
     if path_or_module:
+        if ":" in path_or_module:
+            module_part, func_part = path_or_module.rsplit(":", 1)
+            path_or_module = module_part
+            ctx.params.update({"func": func_part})
         file_path = Path(path_or_module)
         if file_path.exists() and file_path.is_file():
             state.file = file_path


### PR DESCRIPTION
Adds support for specifying functions directly using colon syntax in the typer CLI, as used in pyproject console scripts entrypoint syntax, and projects like uvicorn/gunicorn.

Described in discussion #1274

**Before:**
```bash
$ typer 'autocli.one:step_1' run 123
Not a valid file or Python module: autocli.one:step_1

$ typer --func=step_1 'autocli.one' run 123  # Required explicit --func flag
Step 1: Processing with a=123, result=processed_123.txt
```

**After:**
```bash
$ typer 'autocli.one:step_1' run 123
Step 1: Processing with a=123, result=processed_123.txt

$ typer 'path/to/file.py:step_1' run 123  # Also works with file paths
Step 1: Processing with a=123, result=processed_123.txt
```

The change is pretty minimal - 4 lines added to `maybe_update_state()` to parse the colon syntax and set the function parameter on the click Context params dict which is then picked up in the existing part of the function afterwards.

**Changes:**
- [x] Feature: Parse `"module:function"` and `"/path/to/file.py:function"` syntax in `typer.cli:maybe_update_state`
- [x] Tests: Add coverage of both module and file path variants
- [x] Docs: Updated tutorial with examples