### PR TITLE
Fix: Remove duplicated line in environment-variables.md

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -241,8 +241,6 @@ If you say yes to update the `PATH` environment variable, then the installer wil
 C:\Program Files\Python312\Scripts;C:\Program Files\Python312;C:\Windows\System32;C:\opt\custompython\bin
 ```
 
-This way, when you type `python` in the terminal, the system will find the Python program in `C:\opt\custompython\bin` (the last directory) and use that one.
-
 ////
 
 This way, when you type `python` in the terminal, the system will find the Python program in `/opt/custompython/bin` (the last directory) and use that one.


### PR DESCRIPTION
Removes a duplicate line at line 244 in `typer/docs/environment-variables.md`.

This resolves a minor documentation error where a line was repeated, causing unnecessary visual clutter.