### PR TITLE
👷 Set permissions for conflict detector workflow

### DIFF
--- a/.github/workflows/conflict.yml
+++ b/.github/workflows/conflict.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   main:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check if PRs have merge conflicts


### PR DESCRIPTION
The recently added workflow [failed](https://github.com/fastapi/typer/actions/runs/17378315388/job/49329640509), hoping this will fix it... 