### PR TITLE
✅ Use Ruff rules to ensure safe lazy-loading of `rich`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,12 +164,14 @@ select = [
     "B",  # flake8-bugbear
     "C4",  # flake8-comprehensions
     "UP", # pyupgrade
+    "TID", # flake8-tidy-imports
 ]
 ignore = [
     "E501",  # line too long, handled by black
     "B008",  # do not perform function calls in argument defaults
     "C901",  # too complex
     "W191", # indentation contains tabs
+    "TID252", # Relative imports OK
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -192,6 +194,8 @@ ignore = [
 "docs_src/prompt/tutorial003.py" = ["F841"]
 # Loop control variable `x` not used within loop body
 "docs_src/using_click/tutorial001.py" = ["B007"]
+# No need to avoid rich imports in docs
+"docs_src/*" = ["TID"]
 
 [tool.ruff.lint.isort]
 known-third-party = ["typer", "click"]
@@ -201,3 +205,9 @@ known-first-party = ["reigns", "towns", "lands", "items", "users"]
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true
+
+[tool.ruff.lint.flake8-tidy-imports]
+banned-module-level-imports = ["typer.rich_utils"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"rich".msg = "Use 'typer.rich_utils' instead of importing from 'rich' directly."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 # "__init__.py" = ["F401"]
 # rich_utils is allowed to use rich imports
-"typer\rich_utils.py" = ["TID251"]
+"typer/rich_utils.py" = ["TID251"]
 # This file is more readable without yield from
 "docs_src/progressbar/tutorial004.py" = ["UP028", "B007"]
 # Default mutable data structure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,8 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 # "__init__.py" = ["F401"]
+# rich_utils is allowed to use rich imports
+"typer\rich_utils.py" = ["TID251"]
 # This file is more readable without yield from
 "docs_src/progressbar/tutorial004.py" = ["UP028", "B007"]
 # Default mutable data structure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ ignore = [
     "B008",  # do not perform function calls in argument defaults
     "C901",  # too complex
     "W191", # indentation contains tabs
-    "TID252", # Relative imports OK
+    "TID252", # relative imports okay
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -196,7 +196,7 @@ ignore = [
 "docs_src/prompt/tutorial003.py" = ["F841"]
 # Loop control variable `x` not used within loop body
 "docs_src/using_click/tutorial001.py" = ["B007"]
-# No need to avoid rich imports in docs
+# No need to worry about rich imports in docs
 "docs_src/*" = ["TID"]
 
 [tool.ruff.lint.isort]
@@ -209,6 +209,7 @@ known-first-party = ["reigns", "towns", "lands", "items", "users"]
 keep-runtime-typing = true
 
 [tool.ruff.lint.flake8-tidy-imports]
+# Import rich_utils from within functions (lazy), not at the module level (TID253)
 banned-module-level-imports = ["typer.rich_utils"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]

--- a/tests/assets/type_error_no_rich.py
+++ b/tests/assets/type_error_no_rich.py
@@ -1,7 +1,7 @@
 import typer
 import typer.main
 
-typer.core.HAS_RICH = False
+typer.main.HAS_RICH = False
 
 
 def main(name: str = "morty"):

--- a/tests/assets/type_error_no_rich.py
+++ b/tests/assets/type_error_no_rich.py
@@ -1,7 +1,7 @@
 import typer
 import typer.main
 
-typer.main.rich = None
+typer.core.HAS_RICH = False
 
 
 def main(name: str = "morty"):

--- a/tests/assets/type_error_no_rich_short_disable.py
+++ b/tests/assets/type_error_no_rich_short_disable.py
@@ -1,7 +1,7 @@
 import typer
 import typer.main
 
-typer.core.HAS_RICH = False
+typer.main.HAS_RICH = False
 
 
 app = typer.Typer(pretty_exceptions_short=False)

--- a/tests/assets/type_error_no_rich_short_disable.py
+++ b/tests/assets/type_error_no_rich_short_disable.py
@@ -1,7 +1,7 @@
 import typer
 import typer.main
 
-typer.main.rich = None
+typer.core.HAS_RICH = False
 
 
 app = typer.Typer(pretty_exceptions_short=False)

--- a/tests/test_corner_cases.py
+++ b/tests/test_corner_cases.py
@@ -1,3 +1,4 @@
+import pytest
 import typer.core
 from typer.testing import CliRunner
 
@@ -16,9 +17,9 @@ def test_hidden_option():
     assert "(dynamic)" in result.output
 
 
-def test_hidden_option_no_rich():
-    rich = typer.core.rich
-    typer.core.rich = None
+def test_hidden_option_no_rich(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
+
     result = runner.invoke(mod.app, ["--help"])
     assert result.exit_code == 0
     assert "Say hello" in result.output
@@ -26,7 +27,6 @@ def test_hidden_option_no_rich():
     assert "/lastname" in result.output
     assert "TEST_LASTNAME" in result.output
     assert "(dynamic)" in result.output
-    typer.core.rich = rich
 
 
 def test_coverage_call():

--- a/tests/test_tutorial/test_arguments/test_envvar/test_tutorial001.py
+++ b/tests/test_tutorial/test_arguments/test_envvar/test_tutorial001.py
@@ -33,7 +33,6 @@ def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
     assert "default: World" in result.output
 
 
-
 def test_call_arg():
     result = runner.invoke(app, ["Wednesday"])
     assert result.exit_code == 0

--- a/tests/test_tutorial/test_arguments/test_envvar/test_tutorial001.py
+++ b/tests/test_tutorial/test_arguments/test_envvar/test_tutorial001.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -22,16 +23,15 @@ def test_help():
     assert "default: World" in result.output
 
 
-def test_help_no_rich():
-    rich = typer.core.rich
-    typer.core.rich = None
+def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] [NAME]" in result.output
     assert "Arguments" in result.output
     assert "env var: AWESOME_NAME" in result.output
     assert "default: World" in result.output
-    typer.core.rich = rich
+
 
 
 def test_call_arg():

--- a/tests/test_tutorial/test_arguments/test_envvar/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_arguments/test_envvar/test_tutorial001_an.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -22,16 +23,15 @@ def test_help():
     assert "default: World" in result.output
 
 
-def test_help_no_rich():
-    rich = typer.core.rich
-    typer.core.rich = None
+def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
+
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] [NAME]" in result.output
     assert "Arguments" in result.output
     assert "env var: AWESOME_NAME" in result.output
     assert "default: World" in result.output
-    typer.core.rich = rich
 
 
 def test_call_arg():

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial001.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial001.py
@@ -35,7 +35,6 @@ def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
     assert "[required]" in result.output
 
 
-
 def test_call_arg():
     result = runner.invoke(app, ["Camila"])
     assert result.exit_code == 0

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial001.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial001.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -23,9 +24,8 @@ def test_help():
     assert "[required]" in result.output
 
 
-def test_help_no_rich():
-    rich = typer.core.rich
-    typer.core.rich = None
+def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] NAME" in result.output
@@ -33,7 +33,7 @@ def test_help_no_rich():
     assert "NAME" in result.output
     assert "The name of the user to greet" in result.output
     assert "[required]" in result.output
-    typer.core.rich = rich
+
 
 
 def test_call_arg():

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial001_an.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -23,9 +24,8 @@ def test_help():
     assert "[required]" in result.output
 
 
-def test_help_no_rich():
-    rich = typer.core.rich
-    typer.core.rich = None
+def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] NAME" in result.output
@@ -33,7 +33,6 @@ def test_help_no_rich():
     assert "NAME" in result.output
     assert "The name of the user to greet" in result.output
     assert "[required]" in result.output
-    typer.core.rich = rich
 
 
 def test_call_arg():

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial008.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial008.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -22,16 +23,15 @@ def test_help():
     assert "[default: World]" not in result.output
 
 
-def test_help_no_rich():
-    rich = typer.core.rich
-    typer.core.rich = None
+def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] [NAME]" in result.output
     assert "Say hi to NAME very gently, like Dirk." in result.output
     assert "Arguments" not in result.output
     assert "[default: World]" not in result.output
-    typer.core.rich = rich
+
 
 
 def test_call_arg():

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial008.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial008.py
@@ -33,7 +33,6 @@ def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
     assert "[default: World]" not in result.output
 
 
-
 def test_call_arg():
     result = runner.invoke(app, ["Camila"])
     assert result.exit_code == 0

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial008_an.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial008_an.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -22,16 +23,15 @@ def test_help():
     assert "[default: World]" not in result.output
 
 
-def test_help_no_rich():
-    rich = typer.core.rich
-    typer.core.rich = None
+def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] [NAME]" in result.output
     assert "Say hi to NAME very gently, like Dirk." in result.output
     assert "Arguments" not in result.output
     assert "[default: World]" not in result.output
-    typer.core.rich = rich
+
 
 
 def test_call_arg():

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial008_an.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial008_an.py
@@ -33,7 +33,6 @@ def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
     assert "[default: World]" not in result.output
 
 
-
 def test_call_arg():
     result = runner.invoke(app, ["Camila"])
     assert result.exit_code == 0

--- a/tests/test_tutorial/test_arguments/test_optional/test_tutorial001.py
+++ b/tests/test_tutorial/test_arguments/test_optional/test_tutorial001.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -25,14 +26,12 @@ def test_call_no_arg_standalone():
     assert result.exit_code != 0
 
 
-def test_call_no_arg_no_rich():
+def test_call_no_arg_no_rich(monkeypatch: pytest.MonkeyPatch):
     # Mainly for coverage
-    rich = typer.core.rich
-    typer.core.rich = None
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app)
     assert result.exit_code != 0
     assert "Error: Missing argument 'NAME'" in result.output
-    typer.core.rich = rich
 
 
 def test_call_arg():

--- a/tests/test_tutorial/test_arguments/test_optional/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_arguments/test_optional/test_tutorial001_an.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -25,14 +26,12 @@ def test_call_no_arg_standalone():
     assert result.exit_code != 0
 
 
-def test_call_no_arg_no_rich():
+def test_call_no_arg_no_rich(monkeypatch: pytest.MonkeyPatch):
     # Mainly for coverage
-    rich = typer.core.rich
-    typer.core.rich = None
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app)
     assert result.exit_code != 0
     assert "Error: Missing argument 'NAME'" in result.output
-    typer.core.rich = rich
 
 
 def test_call_arg():

--- a/tests/test_tutorial/test_arguments/test_optional/test_tutorial003.py
+++ b/tests/test_tutorial/test_arguments/test_optional/test_tutorial003.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -25,14 +26,12 @@ def test_call_no_arg_standalone():
     assert result.exit_code != 0
 
 
-def test_call_no_arg_no_rich():
+def test_call_no_arg_no_rich(monkeypatch: pytest.MonkeyPatch):
     # Mainly for coverage
-    rich = typer.core.rich
-    typer.core.rich = None
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app)
     assert result.exit_code != 0
     assert "Error: Missing argument 'NAME'" in result.output
-    typer.core.rich = rich
 
 
 def test_call_arg():

--- a/tests/test_tutorial/test_commands/test_callback/test_tutorial001.py
+++ b/tests/test_tutorial/test_commands/test_callback/test_tutorial001.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer.core
 from typer.testing import CliRunner
 
@@ -19,15 +20,13 @@ def test_help():
     assert "--no-verbose" in result.output
 
 
-def test_help_no_rich():
-    rich = typer.core.rich
-    typer.core.rich = None
+def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "Manage users in the awesome CLI app." in result.output
     assert "--verbose" in result.output
     assert "--no-verbose" in result.output
-    typer.core.rich = rich
 
 
 def test_create():

--- a/tests/test_tutorial/test_options/test_required/test_tutorial001.py
+++ b/tests/test_tutorial/test_options/test_required/test_tutorial001.py
@@ -43,6 +43,7 @@ def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
     assert "TEXT" in result.output
     assert "[required]" in result.output
 
+
 def test_script():
     result = subprocess.run(
         [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],

--- a/tests/test_tutorial/test_options/test_required/test_tutorial001.py
+++ b/tests/test_tutorial/test_options/test_required/test_tutorial001.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -33,16 +34,14 @@ def test_help():
     assert "[required]" in result.output
 
 
-def test_help_no_rich():
-    rich = typer.core.rich
-    typer.core.rich = None
+def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
+    # Mainly for coverage
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "--lastname" in result.output
     assert "TEXT" in result.output
     assert "[required]" in result.output
-    typer.core.rich = rich
-
 
 def test_script():
     result = subprocess.run(

--- a/tests/test_tutorial/test_options/test_required/test_tutorial001.py
+++ b/tests/test_tutorial/test_options/test_required/test_tutorial001.py
@@ -35,7 +35,6 @@ def test_help():
 
 
 def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
-    # Mainly for coverage
     monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0

--- a/tests/test_tutorial/test_options/test_required/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_options/test_required/test_tutorial001_an.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -33,15 +34,14 @@ def test_help():
     assert "[required]" in result.output
 
 
-def test_help_no_rich():
-    rich = typer.core.rich
-    typer.core.rich = None
+def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
+    # Mainly for coverage
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "--lastname" in result.output
     assert "TEXT" in result.output
     assert "[required]" in result.output
-    typer.core.rich = rich
 
 
 def test_script():

--- a/tests/test_tutorial/test_options/test_required/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_options/test_required/test_tutorial001_an.py
@@ -35,7 +35,6 @@ def test_help():
 
 
 def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
-    # Mainly for coverage
     monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0

--- a/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial002.py
+++ b/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial002.py
@@ -23,7 +23,6 @@ def test_help():
 
 
 def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
-    # Mainly for coverage
     monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0

--- a/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial002.py
+++ b/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial002.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -21,15 +22,14 @@ def test_help():
     assert "--no-accept" not in result.output
 
 
-def test_help_no_rich():
-    rich = typer.core.rich
-    typer.core.rich = None
+def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
+    # Mainly for coverage
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "--accept" in result.output
     assert "--reject" in result.output
     assert "--no-accept" not in result.output
-    typer.core.rich = rich
 
 
 def test_main():

--- a/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial002_an.py
+++ b/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial002_an.py
@@ -23,7 +23,6 @@ def test_help():
 
 
 def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
-    # Mainly for coverage
     monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0

--- a/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial002_an.py
+++ b/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial002_an.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -21,15 +22,14 @@ def test_help():
     assert "--no-accept" not in result.output
 
 
-def test_help_no_rich():
-    rich = typer.core.rich
-    typer.core.rich = None
+def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
+    # Mainly for coverage
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "--accept" in result.output
     assert "--reject" in result.output
     assert "--no-accept" not in result.output
-    typer.core.rich = rich
 
 
 def test_main():

--- a/tests/test_tutorial/test_parameter_types/test_number/test_tutorial001.py
+++ b/tests/test_tutorial/test_parameter_types/test_number/test_tutorial001.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -22,17 +23,14 @@ def test_help():
     assert "FLOAT RANGE" in result.output
 
 
-def test_help_no_rich():
-    rich = typer.core.rich
-    typer.core.rich = None
+def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "--age" in result.output
     assert "INTEGER RANGE" in result.output
     assert "--score" in result.output
     assert "FLOAT RANGE" in result.output
-    typer.core.rich = rich
-
 
 def test_params():
     result = runner.invoke(app, ["5", "--age", "20", "--score", "90"])

--- a/tests/test_tutorial/test_parameter_types/test_number/test_tutorial001.py
+++ b/tests/test_tutorial/test_parameter_types/test_number/test_tutorial001.py
@@ -32,6 +32,7 @@ def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
     assert "--score" in result.output
     assert "FLOAT RANGE" in result.output
 
+
 def test_params():
     result = runner.invoke(app, ["5", "--age", "20", "--score", "90"])
     assert result.exit_code == 0

--- a/tests/test_tutorial/test_parameter_types/test_number/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_parameter_types/test_number/test_tutorial001_an.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -22,16 +23,15 @@ def test_help():
     assert "FLOAT RANGE" in result.output
 
 
-def test_help_no_rich():
-    rich = typer.core.rich
-    typer.core.rich = None
+def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
+    # Mainly for coverage
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "--age" in result.output
     assert "INTEGER RANGE" in result.output
     assert "--score" in result.output
     assert "FLOAT RANGE" in result.output
-    typer.core.rich = rich
 
 
 def test_params():

--- a/tests/test_tutorial/test_parameter_types/test_number/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_parameter_types/test_number/test_tutorial001_an.py
@@ -24,7 +24,6 @@ def test_help():
 
 
 def test_help_no_rich(monkeypatch: pytest.MonkeyPatch):
-    # Mainly for coverage
     monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0

--- a/tests/test_tutorial/test_terminating/test_tutorial003.py
+++ b/tests/test_tutorial/test_terminating/test_tutorial003.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 import typer.core
 from typer.testing import CliRunner
@@ -32,15 +33,13 @@ def test_root_no_standalone():
     assert result.exit_code == 1
 
 
-def test_root_no_rich():
+def test_root_no_rich(monkeypatch: pytest.MonkeyPatch):
     # Mainly for coverage
-    rich = typer.core.rich
-    typer.core.rich = None
+    monkeypatch.setattr(typer.core, "HAS_RICH", False)
     result = runner.invoke(app, ["root"])
     assert result.exit_code == 1
     assert "The root user is reserved" in result.output
     assert "Aborted!" in result.output
-    typer.core.rich = rich
 
 
 def test_script():

--- a/typer/cli.py
+++ b/typer/cli.py
@@ -11,14 +11,7 @@ from click import Command, Group, Option
 
 from . import __version__
 
-try:
-    import rich
-
-    has_rich = True
-
-except ImportError:  # pragma: no cover
-    has_rich = False
-    rich = None  # type: ignore
+HAS_RICH = importlib.util.find_spec("rich") is not None
 
 default_app_names = ("app", "cli", "main")
 default_func_names = ("main", "cli", "app")
@@ -272,7 +265,7 @@ def get_docs_for_click(
 
 
 def _parse_html(input_text: str) -> str:
-    if not has_rich:  # pragma: no cover
+    if not HAS_RICH:  # pragma: no cover
         return input_text
     from . import rich_utils
 

--- a/typer/cli.py
+++ b/typer/cli.py
@@ -10,8 +10,7 @@ import typer.core
 from click import Command, Group, Option
 
 from . import __version__
-
-HAS_RICH = importlib.util.find_spec("rich") is not None
+from .core import HAS_RICH
 
 default_app_names = ("app", "cli", "main")
 default_func_names = ("main", "cli", "app")

--- a/typer/core.py
+++ b/typer/core.py
@@ -1,4 +1,5 @@
 import errno
+import importlib.util
 import inspect
 import os
 import sys
@@ -30,13 +31,11 @@ from ._typing import Literal
 
 MarkupMode = Literal["markdown", "rich", None]
 
-try:
-    import rich
+HAS_RICH = importlib.util.find_spec("rich") is not None
 
+if HAS_RICH:
     DEFAULT_MARKUP_MODE: MarkupMode = "rich"
-
-except ImportError:  # pragma: no cover
-    rich = None  # type: ignore
+else:  # pragma: no cover
     DEFAULT_MARKUP_MODE = None
 
 
@@ -210,7 +209,7 @@ def _main(
             if not standalone_mode:
                 raise
             # Typer override
-            if rich and rich_markup_mode is not None:
+            if HAS_RICH and rich_markup_mode is not None:
                 from . import rich_utils
 
                 rich_utils.rich_format_error(e)
@@ -242,7 +241,7 @@ def _main(
         if not standalone_mode:
             raise
         # Typer override
-        if rich and rich_markup_mode is not None:
+        if HAS_RICH and rich_markup_mode is not None:
             from . import rich_utils
 
             rich_utils.rich_abort_error()
@@ -370,7 +369,7 @@ class TyperArgument(click.core.Argument):
         if extra:
             extra_str = "; ".join(extra)
             extra_str = f"[{extra_str}]"
-            if rich is not None:
+            if HAS_RICH:
                 # This is needed for when we want to export to HTML
                 from . import rich_utils
 
@@ -583,7 +582,7 @@ class TyperOption(click.core.Option):
         if extra:
             extra_str = "; ".join(extra)
             extra_str = f"[{extra_str}]"
-            if rich is not None:
+            if HAS_RICH:
                 # This is needed for when we want to export to HTML
                 from . import rich_utils
 
@@ -709,7 +708,7 @@ class TyperCommand(click.core.Command):
         )
 
     def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
-        if not rich or self.rich_markup_mode is None:
+        if not HAS_RICH or self.rich_markup_mode is None:
             return super().format_help(ctx, formatter)
         from . import rich_utils
 
@@ -774,7 +773,7 @@ class TyperGroup(click.core.Group):
         )
 
     def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
-        if not rich or self.rich_markup_mode is None:
+        if not HAS_RICH or self.rich_markup_mode is None:
             return super().format_help(ctx, formatter)
         from . import rich_utils
 

--- a/typer/main.py
+++ b/typer/main.py
@@ -22,6 +22,7 @@ from ._typing import get_args, get_origin, is_union
 from .completion import get_completion_inspect_parameters
 from .core import (
     DEFAULT_MARKUP_MODE,
+    HAS_RICH,
     MarkupMode,
     TyperArgument,
     TyperCommand,
@@ -49,9 +50,6 @@ from .models import (
     TyperPath,
 )
 from .utils import get_params_from_function
-
-HAS_RICH = importlib.util.find_spec("rich") is not None
-
 
 _original_except_hook = sys.excepthook
 _typer_developer_exception_attr_name = "__typer_developer_exception__"

--- a/typer/main.py
+++ b/typer/main.py
@@ -88,7 +88,7 @@ def except_hook(
         if any(frame.filename.startswith(path) for path in internal_dir_names):
             if not exception_config.pretty_exceptions_short:
                 # Hide the line for internal libraries, Typer and Click
-                stack.append(
+                stack.append( # pragma: no cover
                     traceback.FrameSummary(
                         filename=frame.filename,
                         lineno=frame.lineno,

--- a/typer/main.py
+++ b/typer/main.py
@@ -1,4 +1,3 @@
-import importlib.util
 import inspect
 import os
 import platform

--- a/typer/main.py
+++ b/typer/main.py
@@ -88,7 +88,7 @@ def except_hook(
         if any(frame.filename.startswith(path) for path in internal_dir_names):
             if not exception_config.pretty_exceptions_short:
                 # Hide the line for internal libraries, Typer and Click
-                stack.append( # pragma: no cover
+                stack.append(  # pragma: no cover
                     traceback.FrameSummary(
                         filename=frame.filename,
                         lineno=frame.lineno,

--- a/typer/main.py
+++ b/typer/main.py
@@ -88,7 +88,7 @@ def except_hook(
         if any(frame.filename.startswith(path) for path in internal_dir_names):
             if not exception_config.pretty_exceptions_short:
                 # Hide the line for internal libraries, Typer and Click
-                stack.append(  # pragma: no cover
+                stack.append(
                     traceback.FrameSummary(
                         filename=frame.filename,
                         lineno=frame.lineno,

--- a/typer/main.py
+++ b/typer/main.py
@@ -1,3 +1,4 @@
+import importlib.util
 import inspect
 import os
 import platform
@@ -49,11 +50,8 @@ from .models import (
 )
 from .utils import get_params_from_function
 
-try:
-    import rich
+HAS_RICH = importlib.util.find_spec("rich") is not None
 
-except ImportError:  # pragma: no cover
-    rich = None  # type: ignore
 
 _original_except_hook = sys.excepthook
 _typer_developer_exception_attr_name = "__typer_developer_exception__"
@@ -77,7 +75,7 @@ def except_hook(
     click_path = os.path.dirname(click.__file__)
     internal_dir_names = [typer_path, click_path]
     exc = exc_value
-    if rich:
+    if HAS_RICH:
         from . import rich_utils
 
         rich_tb = rich_utils.get_traceback(exc, exception_config, internal_dir_names)

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -1,5 +1,7 @@
 # Extracted and modified from https://github.com/ewels/rich-click
 
+# ruff: noqa: TID251 we are allowed to use rich in this module and assume it is available
+
 import inspect
 import io
 import sys

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -1,7 +1,5 @@
 # Extracted and modified from https://github.com/ewels/rich-click
 
-# ruff: noqa: TID251 we are allowed to use rich in this module and assume it is available
-
 import inspect
 import io
 import sys


### PR DESCRIPTION
To avoid regressions like #1294 occurring in the future, I propose a different way of lazy-loading rich using `importlib.util.find_spec`. I also propose using the `TID` Ruff rules to enforce the lazy-loading logic in the future.

This provides a framework to systematically apply other lazy-loading migrations safely.