### PR TITLE
✨ Allow setting an environment variable to `None` in `CliRunner.invoke`

### DIFF
--- a/typer/testing.py
+++ b/typer/testing.py
@@ -12,7 +12,7 @@ class CliRunner(ClickCliRunner):
         app: Typer,
         args: Optional[Union[str, Sequence[str]]] = None,
         input: Optional[Union[bytes, str, IO[Any]]] = None,
-        env: Optional[Mapping[str, str]] = None,
+        env: Optional[Mapping[str, Optional[str]]] = None,
         catch_exceptions: bool = True,
         color: bool = False,
         **extra: Any,


### PR DESCRIPTION
The type of the Click `env` parameter is `Mapping[str, str | None] | None`. This can be used to "delete" an environment variable.