### PR TITLE
🐛 Ensure that the default `rich_markup_mode` is interpreted correctly

### DIFF
--- a/tests/test_rich_markup_mode.py
+++ b/tests/test_rich_markup_mode.py
@@ -3,6 +3,7 @@ from typing import List
 import pytest
 import typer
 import typer.completion
+from typer.rich_utils import MARKUP_MODE_RICH
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -284,3 +285,10 @@ def test_markup_mode_bullets_double_newline(mode: str, lines: List[str]):
     arg_start = [i for i, row in enumerate(result_lines) if "Arguments" in row][0]
     assert help_start != -1
     assert result_lines[help_start:arg_start] == lines
+
+
+def test_markup_mode_default():
+    app = typer.Typer()
+
+    assert app.rich_markup_mode == MARKUP_MODE_RICH
+

--- a/typer/main.py
+++ b/typer/main.py
@@ -138,7 +138,7 @@ class Typer:
         deprecated: bool = Default(False),
         add_completion: bool = True,
         # Rich settings
-        rich_markup_mode: MarkupMode = Default(DEFAULT_MARKUP_MODE),
+        rich_markup_mode: MarkupMode = DEFAULT_MARKUP_MODE,
         rich_help_panel: Union[str, None] = Default(None),
         pretty_exceptions_enable: bool = True,
         pretty_exceptions_show_locals: bool = True,


### PR DESCRIPTION
By using `Default(DEFAULT_MARKUP_MODE)`, `rich_markup_mode` would be a `typer.models.DefaultPlaceholder` object and comparing it to other literal strings like `MARKUP_MODE_RICH` would fail. This resulted in flaky behaviour such as reported in https://github.com/fastapi/typer/discussions/976, where Rich formatting worked fine when specifying it correctly, but the default value (with Rich installed) didn't result in the same behaviour.

This PR fixes that by simply not using `Default` for this value - there's no real reason to use it anyway, as it's unimportant to the application whether it's a default or a user-set value.