### PR TITLE
✅ Avoid rich formatting in number test

### DIFF
--- a/tests/test_tutorial/test_parameter_types/test_number/test_tutorial001.py
+++ b/tests/test_tutorial/test_parameter_types/test_number/test_tutorial001.py
@@ -9,7 +9,7 @@ from docs_src.parameter_types.number import tutorial001 as mod
 
 runner = CliRunner()
 
-app = typer.Typer()
+app = typer.Typer(rich_markup_mode=None)
 app.command()(mod.main)
 
 

--- a/tests/test_tutorial/test_parameter_types/test_number/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_parameter_types/test_number/test_tutorial001_an.py
@@ -9,7 +9,7 @@ from docs_src.parameter_types.number import tutorial001_an as mod
 
 runner = CliRunner()
 
-app = typer.Typer()
+app = typer.Typer(rich_markup_mode=None)
 app.command()(mod.main)
 
 


### PR DESCRIPTION
The `test_invalid_score` test fails when I run it with my IDE and rich installed, there's a newline right before `x<=100`. I figured just disabling `rich` formatting for this particular test can't hurt.