### PR TITLE
➖ Only install `typing_extensions` for python '<3.10'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 dependencies = [
     "click >= 8.0.0",
-    "typing-extensions >= 3.7.4.3",
+    "typing-extensions >= 3.7.4.3; python_version < '3.10'",
 ]
 readme = "README.md"
 [project.urls]

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,8 +5,8 @@ pytest-cov >=2.10.0,<8.0.0
 coverage[toml] >=6.2,<8.0
 pytest-xdist >=1.32.0,<4.0.0
 pytest-sugar >=0.9.4,<1.2.0
-mypy ==1.4.1
-ruff ==0.12.12
+mypy ==1.18.1
+ruff ==0.13.0
 # Needed explicitly by typer-slim
 rich >=10.11.0
 shellingham >=1.3.0

--- a/tests/assets/cli/rich_formatted_app.py
+++ b/tests/assets/cli/rich_formatted_app.py
@@ -1,5 +1,5 @@
 import typer
-from typing_extensions import Annotated
+from typer._typing import Annotated
 
 app = typer.Typer(rich_markup_mode="rich")
 

--- a/tests/test_ambiguous_params.py
+++ b/tests/test_ambiguous_params.py
@@ -1,5 +1,6 @@
 import pytest
 import typer
+from typer._typing import Annotated
 from typer.testing import CliRunner
 from typer.utils import (
     AnnotatedParamWithDefaultValueError,
@@ -8,7 +9,6 @@ from typer.utils import (
     MultipleTyperAnnotationsError,
     _split_annotation_from_typer_annotations,
 )
-from typing_extensions import Annotated
 
 runner = CliRunner()
 
@@ -93,7 +93,7 @@ def test_allow_multiple_non_typer_params_in_annotated():
     app = typer.Typer()
 
     @app.command()
-    def cmd(my_param: Annotated[str, "someval", typer.Argument(), 4] = "hello"):
+    def cmd(my_param: Annotated[str, "someval", typer.Argument(), 4] = "hello"):  # noqa:F821
         print(my_param)
 
     result = runner.invoke(app)

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -2,8 +2,8 @@ import sys
 from pathlib import Path
 
 import typer
+from typer._typing import Annotated
 from typer.testing import CliRunner
-from typing_extensions import Annotated
 
 from .utils import needs_py310
 

--- a/tests/test_future_annotations.py
+++ b/tests/test_future_annotations.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import typer
+from typer._typing import Annotated
 from typer.testing import CliRunner
-from typing_extensions import Annotated
 
 runner = CliRunner()
 


### PR DESCRIPTION
# Description
1. Only install `typing_extensions` for python '<3.10'
2. Bump up version of ruff/mypy