### PR TITLE
👽️ Ensure compatibility with Click 8.3.0 by restoring the original `value_is_missing` function

### DIFF
--- a/typer/core.py
+++ b/typer/core.py
@@ -609,7 +609,7 @@ def _value_is_missing(param: click.Parameter, value: Any) -> bool:
     #     return True
 
     if (param.nargs != 1 or param.multiple) and value == ():
-        return True    # pragma: no cover
+        return True  # pragma: no cover
 
     return False
 

--- a/typer/core.py
+++ b/typer/core.py
@@ -609,7 +609,7 @@ def _value_is_missing(param: click.Parameter, value: Any) -> bool:
     #     return True
 
     if (param.nargs != 1 or param.multiple) and value == ():
-        return True
+        return True    # pragma: no cover
 
     return False
 

--- a/typer/core.py
+++ b/typer/core.py
@@ -600,7 +600,7 @@ class TyperOption(click.core.Option):
         return _value_is_missing(self, value)
 
 
-def _value_is_missing(param: click.Parameter, value: Any):
+def _value_is_missing(param: click.Parameter, value: Any) -> bool:
     if value is None:
         return True
 

--- a/typer/core.py
+++ b/typer/core.py
@@ -25,7 +25,6 @@ import click.parser
 import click.shell_completion
 import click.types
 import click.utils
-from click._utils import UNSET
 
 from ._typing import Literal
 

--- a/typer/core.py
+++ b/typer/core.py
@@ -25,6 +25,7 @@ import click.parser
 import click.shell_completion
 import click.types
 import click.utils
+from click._utils import UNSET
 
 from ._typing import Literal
 
@@ -403,6 +404,18 @@ class TyperArgument(click.core.Argument):
             var += "..."
         return var
 
+    def value_is_missing(self, value: Any) -> bool:
+        if value is None:
+            return True
+
+        if value is UNSET:
+            return True
+
+        if (self.nargs != 1 or self.multiple) and value == ():
+            return True
+
+        return False
+
 
 class TyperOption(click.core.Option):
     def __init__(
@@ -592,6 +605,18 @@ class TyperOption(click.core.Option):
             help = f"{help}  {extra_str}" if help else f"{extra_str}"
 
         return ("; " if any_prefix_is_slash else " / ").join(rv), help
+
+    def value_is_missing(self, value: Any) -> bool:
+        if value is None:
+            return True
+
+        if value is UNSET:
+            return True
+
+        if (self.nargs != 1 or self.multiple) and value == ():
+            return True
+
+        return False
 
 
 def _typer_format_options(

--- a/typer/core.py
+++ b/typer/core.py
@@ -405,16 +405,7 @@ class TyperArgument(click.core.Argument):
         return var
 
     def value_is_missing(self, value: Any) -> bool:
-        if value is None:
-            return True
-
-        if value is UNSET:
-            return True
-
-        if (self.nargs != 1 or self.multiple) and value == ():
-            return True
-
-        return False
+        return _value_is_missing(self, value)
 
 
 class TyperOption(click.core.Option):
@@ -607,17 +598,21 @@ class TyperOption(click.core.Option):
         return ("; " if any_prefix_is_slash else " / ").join(rv), help
 
     def value_is_missing(self, value: Any) -> bool:
-        if value is None:
-            return True
+        return _value_is_missing(self, value)
 
-        if value is UNSET:
-            return True
 
-        if (self.nargs != 1 or self.multiple) and value == ():
-            return True
+def _value_is_missing(param: click.Parameter, value: Any):
+    if value is None:
+        return True
 
-        return False
+    # Click 8.3 and beyond
+    # if value is UNSET:
+    #     return True
 
+    if (param.nargs != 1 or param.multiple) and value == ():
+        return True
+
+    return False
 
 def _typer_format_options(
     self: click.core.Command, *, ctx: click.Context, formatter: click.HelpFormatter

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -96,7 +96,7 @@ ARGUMENTS_PANEL_TITLE = _("Arguments")
 OPTIONS_PANEL_TITLE = _("Options")
 COMMANDS_PANEL_TITLE = _("Commands")
 ERRORS_PANEL_TITLE = _("Error")
-ABORTED_TEXT = _("Aborted.")
+ABORTED_TEXT = _("Aborted...")
 RICH_HELP = _("Try [blue]'{command_path} {help_option}'[/] for help.")
 
 MARKUP_MODE_MARKDOWN = "markdown"

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -96,7 +96,7 @@ ARGUMENTS_PANEL_TITLE = _("Arguments")
 OPTIONS_PANEL_TITLE = _("Options")
 COMMANDS_PANEL_TITLE = _("Commands")
 ERRORS_PANEL_TITLE = _("Error")
-ABORTED_TEXT = _("Aborted...")
+ABORTED_TEXT = _("Aborted.")
 RICH_HELP = _("Try [blue]'{command_path} {help_option}'[/] for help.")
 
 MARKUP_MODE_MARKDOWN = "markdown"


### PR DESCRIPTION
Yesterday's release of [Click 8.3.0](https://github.com/pallets/click/releases/tag/8.3.0) has [introduced](https://github.com/pallets/click/pull/3030) a new internal variable `UNSET` to differentiate between (truly) unset values and user-provided `None` values. As a consequence, the method `Parameter.value_is_missing` in `click.core` now checks for this `UNSET` value instead of for `None`. 

This results in bugs when using the current Typer with Click 8.3.0+, because a required, unset parameter would be `None` in Typer (and not the new `UNSET` value) and would eventually get the default value instead of throwing an exception.

For instance:
```
@app.command()
def main(name: str):
    print(f"Hello {name}")
```
would result in a print `"Hello None"` when calling it without any arguments.

## Potential solutions

1. A quick fix would be to [pin](https://github.com/fastapi/typer/pull/1336) Typer to <8.3.0, but obviously that would only be temporary.
2. This PR overwrites Click's `value_is_missing` function to revert it back to its functionality from before 8.3.0. This at least makes the test go green, and allows users to install Click 8.3.0+
3. Rewrite Typer's core more fundamentally to exploit the new options of the `UNSET` value. This should also allow us to make different choices with respect to optional flags & flag values, cf https://github.com/fastapi/typer/pull/987. Maybe with the new functionality in Click, we can restore some of that again. But it would require careful refactoring if we also want to continue support Click 8.2 and lower.

## Proposal

At this point in time (right before the weekend 🙃) I suggest to merge this PR (option 2), close #1336 (option 1) and continue working on option 3 in the next few weeks.