### PR TITLE
⬇️ Restrict Click to below 8.3.0 to handle changes in the new version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
-    "click >= 8.0.0",
+    "click >= 8.0.0, < 8.3.0",
     "typing-extensions >= 3.7.4.3",
 ]
 readme = "README.md"


### PR DESCRIPTION
This is temporary, until we straighten out the issues with `UNSET` vs `None`, as introduced by Click 8.3.0. 

Proper fix will be in PR https://github.com/fastapi/typer/pull/1333