### PR TITLE
Fix `--help` text alignment when using typer.style() in option descriptions

### DIFF
--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -167,7 +167,11 @@ def _make_rich_text(
     if markup_mode == MARKUP_MODE_RICH:
         return highlighter(Text.from_markup(text, style=style))
     else:
-        return highlighter(Text(text, style=style))
+        ANSI_ESCAPE_SEQUENCE = "\x1b["
+        if ANSI_ESCAPE_SEQUENCE in text:
+            return highlighter(Text.from_ansi(text, style=style))
+        else:
+            return highlighter(Text(text, style=style))
 
 
 @group()


### PR DESCRIPTION
# Problem

When using typer.style() in help text for CLI options, the help table columns become misaligned. This happens because typer.style() returns a string with ANSI escape codes, and Rich's width calculation includes these control codes, causing incorrect column sizing.

Relevant issue - #1159 

## Root Cause:
The issue occurs in _make_rich_text() function in rich_utils.py. When help text contains ANSI escape codes from typer.style(), the function was creating a plain Text object that preserved the escape codes as literal characters. Rich's width measurement then counted these control codes, causing misalignment.

## Sample Code to reproduce:
```python
from typing import Annotated

import typer

app = typer.Typer()


@app.command()
def example(
    a: Annotated[str, typer.Option(help="This is A")],
    b: Annotated[str, typer.Option(help=f"This is {typer.style('B', underline=True)}")],
):
    pass


if __name__ == "__main__":
    app()

```

## Before fix:
```
❯ python main.py --help
                                                                                                               
 Usage: main.py [OPTIONS]                                                                                      
                                                                                                               
╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────╮
│ *  --a                         TEXT  This is A [required]                                                   │
│ *  --b                         TEXT  This is B [required]                                             │
│    --install-completion              Install completion for the current shell.                              │
│    --show-completion                 Show completion for the current shell, to copy it or customize the     │
│                                      installation.                                                          │
│    --help                            Show this message and exit.                                            │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

## After fix:
```
❯ python main.py --help
                                                                                                               
 Usage: main.py [OPTIONS]                                                                                      
                                                                                                               
╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────╮
│ *  --a                         TEXT  This is A [required]                                                   │
│ *  --b                         TEXT  This is B [required]                                                   │
│    --install-completion              Install completion for the current shell.                              │
│    --show-completion                 Show completion for the current shell, to copy it or customize the     │
│                                      installation.                                                          │
│    --help                            Show this message and exit.                                            │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

## Testing
- [x] Verified with the provided example showing proper alignment
- [x] Tested with various typer.style() combinations
- [x] Confirmed no regression in existing functionality

