### PR TITLE
📝 Remove unnecessary quotes in `printing.md`

### DIFF
--- a/docs/tutorial/printing.md
+++ b/docs/tutorial/printing.md
@@ -232,7 +232,7 @@ You can create colored strings to output to the terminal with `typer.style()`, t
 
 /// tip
 
-The parameters `fg` and `bg` receive strings with the color names for the "**f**ore**g**round" and "**b**ack**g**round" colors. You could simply pass `fg="green"` and `bg="red"`.
+The parameters `fg` and `bg` receive strings with the color names for the **f**ore**g**round and **b**ack**g**round colors. You could simply pass `fg="green"` and `bg="red"`.
 
 But **Typer** provides them all as variables like `typer.colors.GREEN` just so you can use autocompletion while selecting them.
 


### PR DESCRIPTION
On currenty `master`, this now prints as:

<img width="1258" height="105" alt="image" src="https://github.com/user-attachments/assets/bd680482-9de9-431f-8233-f14249307812" />

So better to remove the quotes and ensure the bold actually works.