### PR TITLE
docs: fix CliRunner.invoke() docstring to reference 'app' parameter

### DIFF
--- a/typer/testing.py
+++ b/typer/testing.py
@@ -18,6 +18,28 @@ class CliRunner(ClickCliRunner):
         color: bool = False,
         **extra: Any,
     ) -> Result:
+        """Invokes a Typer application in an isolated environment.
+
+        This is a Typer-specific wrapper around Click's CliRunner.invoke() method.
+        The arguments are forwarded directly to the command line script, the `extra`
+        keyword arguments are passed to the :meth:`~click.Command.main` function of
+        the command.
+
+        This returns a :class:`click.testing.Result` object.
+
+        :param app: the Typer application to invoke
+        :param args: the arguments to invoke. It may be given as an iterable
+                     or a string. When given as string it will be interpreted
+                     as a Unix shell command. More details at
+                     :func:`shlex.split`.
+        :param input: the input data for `sys.stdin`.
+        :param env: the environment overrides.
+        :param catch_exceptions: Whether to catch any other exceptions than
+                                 ``SystemExit``.
+        :param color: whether the output should contain color codes. The
+                      application can still override this explicitly.
+        :param extra: the keyword arguments to pass to :meth:`main`.
+        """
         use_cli = _get_command(app)
         return super().invoke(
             use_cli,


### PR DESCRIPTION
## What I Fixed
The `CliRunner.invoke()` method had outdated documentation that referenced a `cli` parameter, but the actual parameter is called `app`.

## Why This Matters
When developers use `CliRunner` for testing, they see documentation mentioning a parameter that doesn't exist. This happens because Typer's `CliRunner` inherits the docstring from Click's version, which uses different parameter names.

Now the docs correctly show that you pass in a `Typer` application object via the `app` parameter.

## Changes Made
- Changed `:param cli:` to `:param app:` in the docstring
- Added a note explaining this is a Typer-specific wrapper around Click's CliRunner
