### PR TITLE
fix: show default values for single boolean flags with default=False

### DIFF
--- a/typer/core.py
+++ b/typer/core.py
@@ -125,13 +125,6 @@ def _get_default_string(
         else:
             default_string = _split_opt(obj.secondary_opts[0])[1]
         # Typer override end
-    elif (
-        isinstance(obj, TyperOption)
-        and obj.is_bool_flag
-        and not obj.secondary_opts
-        and not default_value
-    ):
-        default_string = ""
     else:
         default_string = str(default_value)
     return default_string


### PR DESCRIPTION
Previously, single boolean flags (without secondary --no-* options) with `default=False` would not display their default value in help text, even when `show_default=True` was set. This made it inconsistent with dual-flag
options and other parameter types.

Removed the special case in `_get_default_string()` that hid defaults for single boolean flags with falsy default values. Now all boolean flags consistently show their default values in help text.

```python
    dry_run: bool = typer.Option(
        False,
        "--dry-run",
        help="Simulate uploads without actually uploading",
    ),
```
```
Before: --dry-run    Simulate uploads without actually uploading
After:  --dry-run    Simulate uploads without actually uploading [default: False]
```
