### PR TITLE
Raise clear error for multiple variadic arguments

### DIFF
--- a/tests/test_type_conversion.py
+++ b/tests/test_type_conversion.py
@@ -168,3 +168,15 @@ def test_custom_click_type():
 
     result = runner.invoke(app, ["0x56"])
     assert result.exit_code == 0
+
+
+def test_multiple_list_arguments_error():
+    """Test that multiple List arguments raises a clear error (issue #260)."""
+    app = typer.Typer()
+
+    @app.command()
+    def cmd(names: list[str], others: list[str]):
+        print(f"names={names}, others={others}")
+
+    with pytest.raises(click.UsageError, match="Only one argument can take multiple values"):
+        runner.invoke(app, ["a", "b"], catch_exceptions=False)

--- a/typer/main.py
+++ b/typer/main.py
@@ -1376,6 +1376,16 @@ def get_params_convertors_ctx_param_name_from_function(
             if convertor:
                 convertors[param_name] = convertor
             params.append(click_param)
+    variadic_args = [
+        p.name for p in params if isinstance(p, click.Argument) and p.nargs < 0
+    ]
+    if len(variadic_args) > 1:
+        names = ", ".join(f"'{n}'" for n in variadic_args)
+        raise click.UsageError(
+            f"Only one argument can take multiple values (nargs=-1), but "
+            f"{len(variadic_args)} were found: {names}. "
+            f"Use List[...] (or Sequence[...]) for at most one argument."
+        )
     return params, convertors, context_param_name
 
 


### PR DESCRIPTION
## Summary

Closes #260.

When a command has more than one argument annotated with `List[...]` (or any type that maps to `nargs=-1`), Click raises an opaque `TypeError: Cannot have two nargs < 0`. This PR adds early validation in Typer's parameter collection to detect multiple variadic arguments and raise a clear `UsageError` explaining the constraint.

## Changes

- Added validation after parameter collection in `get_params_convertors_ctx_param_name_from_function()` to check for multiple arguments with `nargs < 0`
- Raises `click.UsageError` with a message naming all conflicting arguments
- Added test `test_multiple_list_arguments_error` in `tests/test_type_conversion.py`

## Example

Before:
```
TypeError: Cannot have two nargs < 0
```

After:
```
UsageError: Only one argument can take multiple values (nargs=-1), but 2 were found: 'names', 'others'. Use List[...] (or Sequence[...]) for at most one argument.
```