### PR TITLE
📝 Add docstrings to testing module

### DIFF
--- a/typer/testing.py
+++ b/typer/testing.py
@@ -1,3 +1,13 @@
+"""Testing utilities for Typer applications.
+
+Provides a `CliRunner` that wraps Click's test runner with Typer-aware
+`invoke`, so you can test `Typer` apps directly without converting them
+to Click commands by hand.
+
+Read more in the
+[Typer docs for Testing](https://typer.tiangolo.com/tutorial/testing/).
+"""
+
 from collections.abc import Mapping, Sequence
 from typing import IO, Any
 
@@ -8,6 +18,36 @@ from typer.main import get_command as _get_command
 
 
 class CliRunner(ClickCliRunner):
+    """A test runner for `Typer` applications.
+
+    Extends Click's `CliRunner` with a Typer-aware `invoke` method that
+    accepts a `Typer` instance directly, removing the need to call
+    `typer.main.get_command` in every test.
+
+    Read more in the
+    [Typer docs for Testing](https://typer.tiangolo.com/tutorial/testing/).
+
+    ## Example
+
+    ```python
+    from typer.testing import CliRunner
+    import typer
+
+    app = typer.Typer()
+
+    @app.command()
+    def hello(name: str) -> None:
+        typer.echo(f"Hello {name}")
+
+    runner = CliRunner()
+
+    def test_hello() -> None:
+        result = runner.invoke(app, ["World"])
+        assert result.exit_code == 0
+        assert "Hello World" in result.output
+    ```
+    """
+
     def invoke(  # type: ignore
         self,
         app: Typer,
@@ -18,6 +58,14 @@ class CliRunner(ClickCliRunner):
         color: bool = False,
         **extra: Any,
     ) -> Result:
+        """Invoke a `Typer` app in an isolated environment for testing.
+
+        Converts the `Typer` instance to a Click command and delegates to
+        Click's `CliRunner.invoke`.
+
+        Read more in the
+        [Typer docs for Testing](https://typer.tiangolo.com/tutorial/testing/).
+        """
         use_cli = _get_command(app)
         return super().invoke(
             use_cli,


### PR DESCRIPTION
## Summary

`typer/testing.py` shipped with no docstrings on the module, the `CliRunner` class, or its `invoke` method. This PR adds all three.

- **Module docstring** — brief description of the module's purpose with a link to the testing tutorial.
- **`CliRunner` class docstring** — explains what it extends and why, with a short usage example that mirrors the style used for the `Typer` class in `typer/main.py`.
- **`CliRunner.invoke` docstring** — describes what the method does and delegates to for readers who land on the API reference.

No logic, behaviour, or type annotations were changed. The diff is +48 / -0 lines.

## Checklist

- [x] Docstring style matches existing project conventions (plain prose, Markdown, links to the tutorial)
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] No test files modified
- [x] No logic changes