### PR TITLE
fix: pwsh autocompletion not returning command hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ htmlcov
 coverage.xml
 .coverage*
 .cache
+venv/

--- a/typer/_completion_classes.py
+++ b/typer/_completion_classes.py
@@ -182,7 +182,13 @@ class PowerShellComplete(click.shell_completion.ShellComplete):
         completion_args = os.getenv("_TYPER_COMPLETE_ARGS", "")
         incomplete = os.getenv("_TYPER_COMPLETE_WORD_TO_COMPLETE", "")
         cwords = click_split_arg_string(completion_args)
-        args = cwords[1:-1] if incomplete else cwords[1:]
+        # cwords[0] is the interpreter (e.g. "python"), cwords[1] is the
+        # prog name (e.g. "main.py") — skip both, same as bash/zsh do with
+        # their respective word splitting. Without this, the prog name leaks
+        # into args and Click can't resolve the command context, causing
+        # completions to silently return nothing (issue #266).
+        
+        args = cwords[2:-1] if incomplete else cwords[2:]
         return args, incomplete
 
     def format_completion(self, item: click.shell_completion.CompletionItem) -> str:

--- a/typer/_completion_classes.py
+++ b/typer/_completion_classes.py
@@ -187,7 +187,7 @@ class PowerShellComplete(click.shell_completion.ShellComplete):
         # their respective word splitting. Without this, the prog name leaks
         # into args and Click can't resolve the command context, causing
         # completions to silently return nothing (issue #266).
-        
+
         args = cwords[2:-1] if incomplete else cwords[2:]
         return args, incomplete
 

--- a/typer/_completion_shared.py
+++ b/typer/_completion_shared.py
@@ -55,9 +55,9 @@ $scriptblock = {
         [System.Management.Automation.CompletionResult]::new(
             $command, $command, 'ParameterValue', $helpString)
     }
-    $Env:%(autocomplete_var)s = ""
-    $Env:_TYPER_COMPLETE_ARGS = ""
-    $Env:_TYPER_COMPLETE_WORD_TO_COMPLETE = ""
+    Remove-Item Env:%(autocomplete_var)s -ErrorAction SilentlyContinue
+    Remove-Item Env:_TYPER_COMPLETE_ARGS -ErrorAction SilentlyContinue
+    Remove-Item Env:_TYPER_COMPLETE_WORD_TO_COMPLETE -ErrorAction SilentlyContinue
 }
 Register-ArgumentCompleter -Native -CommandName %(prog_name)s -ScriptBlock $scriptblock
 """


### PR DESCRIPTION
Closes #266

## What's the bug?
`PowerShellComplete.get_completion_args()` was slicing `cwords[1:]` to skip the interpreter, but `$commandAst.ToString()` in the PowerShell template includes both the interpreter (`python`) and the prog name (`main.py`) as the first two tokens.

This meant `main.py` was leaking into the args passed to Click's completion resolver, which couldn't match it to any command and returned no completions — causing PowerShell to silently fall back to path-only completion.

## Changes
**`typer/_completion_classes.py`**
- Changed `cwords[1:]` → `cwords[2:]` and `cwords[1:-1]` → `cwords[2:-1]` in `PowerShellComplete.get_completion_args()` to correctly skip both the interpreter and prog name tokens.

**`typer/_completion_shared.py`**
- Replaced `$Env:VAR = ""` with `Remove-Item Env:VAR` to fully unset environment variables after completion, preventing stale values from affecting repeated completions.

## Testing
Tested by mocking `_TYPER_COMPLETE_ARGS` and `_TYPER_COMPLETE_WORD_TO_COMPLETE` env vars and asserting correct args slicing before and after the fix. Also verified end-to-end with `pwsh` on Linux.