### PR TITLE
docs: fix environment variable wording

### DIFF
--- a/docs/tutorial/exceptions.md
+++ b/docs/tutorial/exceptions.md
@@ -43,7 +43,7 @@ $ python main.py
 
 ## Exceptions without Rich
 
-You can disable Rich globally using the environmental variable `TYPER_USE_RICH`.
+You can disable Rich globally using the environment variable `TYPER_USE_RICH`.
 
 In this case, Typer will still do some tricks to show you the information **as clearly as possible**:
 


### PR DESCRIPTION
## Summary
Fix wording in `docs/tutorial/exceptions.md` by changing `environmental variable` to `environment variable`.

## Related issue
N/A

## Guideline alignment
Single-file documentation-only change with no behavior change.

## Validation
Not run; documentation-only change.
