### PR TITLE
✨ Expose `FileTextRead` from `__init__.py`

### DIFF
--- a/typer/__init__.py
+++ b/typer/__init__.py
@@ -34,6 +34,7 @@ from .models import Context as Context
 from .models import FileBinaryRead as FileBinaryRead
 from .models import FileBinaryWrite as FileBinaryWrite
 from .models import FileText as FileText
+from .models import FileTextRead as FileTextRead
 from .models import FileTextWrite as FileTextWrite
 from .params import Argument as Argument
 from .params import Option as Option


### PR DESCRIPTION
I think this was an oversight, given that `FileBinaryRead`, `FileBinaryWrite` and `FileTextWrite` are all exposed.

This came up as I'm writing tests for a different PR and wanted to use `typer.FileTextRead`.