### PR TITLE
🐛 Fix zsh completion install to respect `$ZDOTDIR`

### DIFF
--- a/tests/test_completion/test_completion_install.py
+++ b/tests/test_completion/test_completion_install.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest import mock
 
 import shellingham
+from typer._completion_shared import install_zsh
 from typer.testing import CliRunner
 
 from docs_src.typer_app import tutorial001_py310 as mod
@@ -171,3 +172,35 @@ def test_completion_install_powershell():
     assert install_script in new_text
     assert "completion installed in" in result.stdout
     assert "Completion will take effect once you restart the terminal" in result.stdout
+
+
+def test_install_zsh_respects_zdotdir(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    zdotdir = tmp_path / "custom"
+    zdotdir.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("ZDOTDIR", str(zdotdir))
+    install_zsh(prog_name="demo", complete_var="_DEMO_COMPLETE", shell="zsh")
+    assert (zdotdir / ".zshrc").is_file()
+    assert not (home / ".zshrc").exists()
+    assert "fpath+=~/.zfunc" in (zdotdir / ".zshrc").read_text()
+
+
+def test_install_zsh_without_zdotdir_uses_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("ZDOTDIR", raising=False)
+    install_zsh(prog_name="demo", complete_var="_DEMO_COMPLETE", shell="zsh")
+    assert (home / ".zshrc").is_file()
+    assert "fpath+=~/.zfunc" in (home / ".zshrc").read_text()
+
+
+def test_install_zsh_empty_zdotdir_uses_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("ZDOTDIR", "")
+    install_zsh(prog_name="demo", complete_var="_DEMO_COMPLETE", shell="zsh")
+    assert (home / ".zshrc").is_file()

--- a/typer/_completion_shared.py
+++ b/typer/_completion_shared.py
@@ -118,7 +118,11 @@ def install_bash(*, prog_name: str, complete_var: str, shell: str) -> Path:
 
 def install_zsh(*, prog_name: str, complete_var: str, shell: str) -> Path:
     # Setup Zsh and load ~/.zfunc
-    zshrc_path = Path.home() / ".zshrc"
+    # Respect ZDOTDIR if it is set to a non-empty value, as Zsh itself does.
+    # Ref: https://zsh.sourceforge.io/Doc/Release/Files.html
+    zdotdir = os.environ.get("ZDOTDIR")
+    zshrc_dir = Path(zdotdir) if zdotdir else Path.home()
+    zshrc_path = zshrc_dir / ".zshrc"
     zshrc_path.parent.mkdir(parents=True, exist_ok=True)
     zshrc_content = ""
     if zshrc_path.is_file():


### PR DESCRIPTION
When `$ZDOTDIR` is set, Zsh reads `.zshrc` from that directory instead of `$HOME`, so writing the completion init line to `~/.zshrc` has no effect and completions silently fail to load (as noted in the issue and reproduced in the linked comment). This honors `$ZDOTDIR` when it is set to a non-empty value and falls back to `$HOME` otherwise, matching Zsh's own behavior.

Added three unit tests around `install_zsh` (ZDOTDIR set, unset, empty). The existing `test_completion_install_zsh` integration test still passes with `_TYPER_RUN_INSTALL_COMPLETION_TESTS=1`.

Fixes #171