### PR TITLE
🐛 Ensure that `typer.launch` forwards correctly when launching a file

### DIFF
--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 import typer
+
 from tests.utils import needs_windows
 
 url = "http://example.com"

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 import typer
+from tests.utils import needs_windows
 
 url = "http://example.com"
 
@@ -49,8 +50,15 @@ def test_launch_url_no_xdg_open():
     mock_webbrowser_open.assert_called_once_with(url)
 
 
-def test_calls_original_launch_when_not_passing_urls():
-    with patch("typer.main.click.launch", return_value=0) as launch_mock:
-        typer.launch("not a url")
+@needs_windows
+def test_launch_file():
+    with (
+        patch("click._termui_impl.sys.platform", "win32"),
+        patch("click._termui_impl.WIN", True),
+        patch("click._termui_impl.CYGWIN", False),
+        patch("subprocess.call", return_value=0) as call_mock,
+    ):
+        result = typer.launch("C:/tmp/file.txt", locate=True)
 
-    launch_mock.assert_called_once_with("not a url")
+    assert result == 0
+    call_mock.assert_called_once_with(["explorer", "/select,C:/tmp/file.txt"])

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -51,6 +51,13 @@ def test_launch_url_no_xdg_open():
     mock_webbrowser_open.assert_called_once_with(url)
 
 
+def test_calls_original_launch_when_not_passing_urls():
+    with patch("typer.main.click.launch", return_value=0) as launch_mock:
+        typer.launch("not a url")
+
+    launch_mock.assert_called_once_with("not a url", wait=False, locate=False)
+
+
 @needs_windows
 def test_launch_file():
     with (

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,6 +9,9 @@ from typer.core import HAS_RICH
 needs_linux = pytest.mark.skipif(
     not sys.platform.startswith("linux"), reason="Test requires Linux"
 )
+needs_windows = pytest.mark.skipif(
+    not sys.platform.startswith("win"), reason="Test requires Windows"
+)
 
 needs_rich = pytest.mark.skipif(not HAS_RICH, reason="Test requires Rich")
 

--- a/typer/main.py
+++ b/typer/main.py
@@ -2010,4 +2010,4 @@ def launch(
         return 0
 
     else:
-        return click.launch(url)
+        return click.launch(url, wait=wait, locate=locate)


### PR DESCRIPTION
The current code in `main.py` didn't forward the `locate` and `wait` arguments to click. When launching a file and setting `locate=True`, Click would open a file manager instead of launching the file directly. The Typer docstring indicate the same behaviour is targeted.

From the added unit test in this PR, we see this isn't actually happening on `master`. When forwarding the arguments correctly, the behaviour is as expected.

Running this test on Windows only because it doesn't feel necessary to mock this behaviour for the various OS's.