### PR TITLE
Fix typos in internal code comments

### DIFF
--- a/typer/core.py
+++ b/typer/core.py
@@ -340,7 +340,7 @@ class TyperArgument(click.core.Argument):
                 extra.append(f"env var: {var_str}")
 
         # Typer override:
-        # Extracted to _extract_default_help_str() to allow re-using it in rich_utils
+        # Extracted to _extract_default_help_str() to allow reusing it in rich_utils
         default_value = self._extract_default_help_str(ctx=ctx)
         # Typer override end
 
@@ -350,7 +350,7 @@ class TyperArgument(click.core.Argument):
             default_value is not None and (self.show_default or ctx.show_default)
         ):
             # Typer override:
-            # Extracted to _get_default_string() to allow re-using it in rich_utils
+            # Extracted to _get_default_string() to allow reusing it in rich_utils
             default_string = self._get_default_string(
                 ctx=ctx,
                 show_default_is_str=show_default_is_str,
@@ -539,7 +539,7 @@ class TyperOption(click.core.Option):
                 extra.append(_("env var: {var}").format(var=var_str))
 
         # Typer override:
-        # Extracted to _extract_default() to allow re-using it in rich_utils
+        # Extracted to _extract_default() to allow reusing it in rich_utils
         default_value = self._extract_default_help_str(ctx=ctx)
         # Typer override end
 
@@ -549,7 +549,7 @@ class TyperOption(click.core.Option):
             default_value is not None and (self.show_default or ctx.show_default)
         ):
             # Typer override:
-            # Extracted to _get_default_string() to allow re-using it in rich_utils
+            # Extracted to _get_default_string() to allow reusing it in rich_utils
             default_string = self._get_default_string(
                 ctx=ctx,
                 show_default_is_str=show_default_is_str,

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -217,7 +217,7 @@ def _get_help_text(
 
     # Get remaining lines, remove single line breaks and format as dim
     if remaining_paragraphs:
-        # Add a newline inbetween the header and the remaining paragraphs
+        # Add a newline in between the header and the remaining paragraphs
         yield Text("")
         # Join with double linebreaks for markdown and Rich markup
         remaining_lines = "\n\n".join(remaining_paragraphs)


### PR DESCRIPTION

**Repo:** tiangolo/typer (⭐ 16000)
**Type:** docs
**Files changed:** 2
**Lines:** +5/-5

## What
Fixes small typos in internal code comments identified by `codespell`:
- `re-using` → `reusing` (4 occurrences in `typer/core.py`)
- `inbetween` → `in between` (1 occurrence in `typer/rich_utils.py`)

No behavior change — only comment wording.

## Why
"Reusing" (no hyphen) and "in between" (two words) are the standard forms. Keeps the codebase tidy and removes noise from spellcheck tooling.

## Testing
No runtime code paths modified; only comments changed. Ran `codespell` on the touched files to confirm the flagged issues are gone.

## Risk
Low — comment-only edits.
