### PR TITLE
fix: respect ZDOTDIR env var for zsh completion install

### DIFF
--- a/typer/_completion_shared.py
+++ b/typer/_completion_shared.py
@@ -118,7 +118,9 @@ def install_bash(*, prog_name: str, complete_var: str, shell: str) -> Path:
 
 def install_zsh(*, prog_name: str, complete_var: str, shell: str) -> Path:
     # Setup Zsh and load ~/.zfunc
-    zshrc_path = Path.home() / ".zshrc"
+    # Respect ZDOTDIR: zsh uses $ZDOTDIR/.zshrc instead of $HOME/.zshrc
+    zdotdir = Path(os.environ.get("ZDOTDIR", Path.home()))
+    zshrc_path = zdotdir / ".zshrc"
     zshrc_path.parent.mkdir(parents=True, exist_ok=True)
     zshrc_content = ""
     if zshrc_path.is_file():


### PR DESCRIPTION
## Summary

Respect the `ZDOTDIR` environment variable when installing zsh completion.

## Problem

When running `--install-completion zsh`, Typer always writes to `$HOME/.zshrc`. However, zsh supports the `ZDOTDIR` environment variable to override the directory where `.zshrc` lives. Users who set `ZDOTDIR` (e.g., `export ZDOTDIR=~/.config/zsh`) have their completion installed to the wrong file.

## Fix

In `install_zsh()`, check `os.environ.get("ZDOTDIR")` and use it as the base directory for `.zshrc` instead of always using `$HOME`. Falls back to `$HOME` when `ZDOTDIR` is not set.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

Fixes #171