### PR TITLE
👷 Configure Dependabot to group updates and update weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,26 +4,47 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
     commit-message:
       prefix: ⬆
+    labels:
+      - "internal"
+      - "dependencies"
+      - "github_actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   # Python
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
     commit-message:
       prefix: ⬆
+    groups:
+      python-packages:
+        dependency-type: "development"
+        patterns:
+          - "*"
   # pre-commit
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
     commit-message:
       prefix: ⬆
+    labels:
+      - "internal"
+      - "dependencies"
+      - "pre-commit"
+    groups:
+      pre-commit:
+        patterns:
+          - "*"


### PR DESCRIPTION
👷 Configure Dependabot to group updates and update weekly + specify labels for github-actions and pre-commit ecosystems

Added `pre-commit` label to the list of available labels in this repo

See https://github.com/tiangolo/library-skills/pull/85