### PR TITLE
🐛 Ensure that an envvar set for `typer.Option` works as expected

### DIFF
--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -325,6 +325,18 @@ def test_empty_list_default_generator():
     assert "[]" in result.output
 
 
+def test_option_uses_envvar_when_required():
+    app = typer.Typer()
+
+    @app.command()
+    def main(user: Annotated[str, typer.Option(envvar="ME")]):
+        print(f"Hello {user}")
+
+    result = runner.invoke(app, env={"ME": "rick"})
+    assert result.exit_code == 0
+    assert "Hello rick" in result.output
+
+
 def test_completion_argument():
     file_path = Path(__file__).parent / "assets/completion_argument.py"
     result = subprocess.run(

--- a/typer/core.py
+++ b/typer/core.py
@@ -672,6 +672,7 @@ class TyperOption(_click.Parameter):
         # Absent environment variable or an empty string is interpreted as unset.
         if rv is None:
             return None
+        return rv
 
     def resolve_envvar_value(self, ctx: _click.Context) -> str | None:
         rv = super().resolve_envvar_value(ctx)


### PR DESCRIPTION
Fixes #1787, thanks to @wpk-nist-gov for the report in #1786.

## Description

In the Click vendoring PR leading up to release 0.26.0, at a certain point I merged Click's `Option` with `TyperOption`. For the function `value_from_envvar` (original [here](https://github.com/fastapi/typer/pull/1680/changes#diff-f64afa0f090240e94c549facdac90bc6ba66f6c311d2de6c15d4fb17d45742c3L2882)) I removed some flag-related stuff that shouldn't be relevant to Typer, but I must have mistakingly also removed the final return statement `return rv` when there is a relevant envvar set. The commit that produced this bug was [this one](https://github.com/fastapi/typer/pull/1680/changes/aceec404753a94db92310b958da4a0834461f527).

There wasn't a regression test to catch this, so this PR adds one.

## AI Disclaimer

Used Cursor to help me debug the issue more quickly, manually reviewed everything in detail.


## Checklist

- [x] I added tests for the change.
- [x] The new or updated tests fail on the main branch and pass on this PR.
- [x] Coverage stays at 100%.
