### PR TITLE
🐛 Ensure that an envvar set for a `typer.Option` list is split on whitespace

### DIFF
--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -340,13 +340,15 @@ def test_option_envvar():
 def test_option_envvar_list():
     app = typer.Typer()
 
-    @app.command("opt")
-    def from_option(user: Annotated[list[str], typer.Option(envvar="ME")]):
-        print(f"Hello {user}")
+    @app.command()
+    def main(users: Annotated[list[str], typer.Option(envvar="ME")]):
+        for u in users:
+            print(f"Hello {u}")
 
-    result = runner.invoke(app, env={"ME": "rick and morty"})
+    result = runner.invoke(app, env={"ME": "rick morty"})
     assert result.exit_code == 0
-    assert "Hello ['rick', 'and', 'morty']" in result.output
+    assert "Hello rick" in result.output
+    assert "Hello morty" in result.output
 
 
 def test_completion_argument():

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -325,7 +325,7 @@ def test_empty_list_default_generator():
     assert "[]" in result.output
 
 
-def test_option_uses_envvar_when_required():
+def test_option_envvar():
     app = typer.Typer()
 
     @app.command()
@@ -335,6 +335,18 @@ def test_option_uses_envvar_when_required():
     result = runner.invoke(app, env={"ME": "rick"})
     assert result.exit_code == 0
     assert "Hello rick" in result.output
+
+
+def test_option_envvar_list():
+    app = typer.Typer()
+
+    @app.command("opt")
+    def from_option(user: Annotated[list[str], typer.Option(envvar="ME")]):
+        print(f"Hello {user}")
+
+    result = runner.invoke(app, env={"ME": "rick and morty"})
+    assert result.exit_code == 0
+    assert "Hello ['rick', 'and', 'morty']" in result.output
 
 
 def test_completion_argument():

--- a/typer/core.py
+++ b/typer/core.py
@@ -667,11 +667,16 @@ class TyperOption(_click.Parameter):
         )
 
     def value_from_envvar(self, ctx: _click.Context) -> Any:
+        # TODO: clean up
         rv = self.resolve_envvar_value(ctx)
 
         # Absent environment variable or an empty string is interpreted as unset.
         if rv is None:
             return None
+
+        if self.nargs != 1 or self.multiple:
+            return self.type.split_envvar_value(rv)
+
         return rv
 
     def resolve_envvar_value(self, ctx: _click.Context) -> str | None:


### PR DESCRIPTION
Fixes #1789, thanks to @wpk-nist-gov for the report.

## Description

This bug fix is related to #1787 though not quite the same. A user reported that this doesn't work anymore:

```
def from_option(user: Annotated[list[str], typer.Option(envvar="ME")]):
    print(f"Hello {user}")
```

As far as I know, we don't actually document using `envvar` in combination with a `list` type. Before 0.26.0, Click's defaults would parse the envvar string on whitespace and produce a list when calling this with something like `env={"ME": "rick morty"}`. 

This currently still works for `Argument` as it doesn't have its own implementation of `value_from_envvar`, it still uses Click's old one from `Parameter`. For `Option`, this functionality was removed in the refactor. This PR restores the functionality for `Option` in a quick bug fix PR. `Argument` and `Option` should work similarly, which is now the case with this PR. For the future, we should consider whether we want to keep & document this behaviour.

## AI Disclaimer

Used Cursor to help me debug the issue more quickly, manually reviewed everything in detail.


## Checklist

- [x] I added tests for the change.
- [x] The new or updated tests fail on the main branch and pass on this PR.
- [x] Coverage stays at 100%.
