### PR TITLE
fix: respect TYPER_USE_RICH in completion help text (fixes #1643)

### DIFF
--- a/typer/_completion_classes.py
+++ b/typer/_completion_classes.py
@@ -20,6 +20,9 @@ def _sanitize_help_text(text: str) -> str:
     """Sanitizes the help text by removing rich tags"""
     if not importlib.util.find_spec("rich"):
         return text
+    # Respect TYPER_USE_RICH environment variable
+    if os.getenv("TYPER_USE_RICH", "").lower() in ("false", "0", "no", "off"):
+        return text
     from . import rich_utils
 
     return rich_utils.rich_render_text(text)


### PR DESCRIPTION
Fixes #1643: _sanitize_help_text now checks TYPER_USE_RICH env var