### PR TITLE
🐛 Ensure that the default of a list argument is used correctly

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -109,6 +109,12 @@ def test_split_envvar_value(monkeypatch) -> None:
     assert "Hello Morty!" in result.output
 
 
+def test_variadic_argument_empty() -> None:
+    result = runner.invoke(app, ["hello-all"])
+    assert result.exit_code == 0
+    assert "Hello World!" in result.output
+
+
 def test_list_pair() -> None:
     result = runner.invoke(app, ["split-variadic-and-pair", "a", "b", "c", "x", "y"])
     assert result.exit_code == 0

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -115,7 +115,9 @@ def test_enum_choice_missing_message() -> None:
 
 
 def test_list() -> None:
-    result = runner.invoke(app, ["hello-all-options", "--name", "Rick", "--name", "Morty"])
+    result = runner.invoke(
+        app, ["hello-all-options", "--name", "Rick", "--name", "Morty"]
+    )
     assert result.exit_code == 0
     assert "Hello World!" not in result.output
     assert "Hello Rick!" in result.output

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -31,7 +31,13 @@ def hello_no_choices(
 
 
 @app.command()
-def hello_all(names: list[str] = typer.Argument(["World"])) -> None:
+def hello_all_options(name: list[str] = typer.Option(["World"])) -> None:
+    for n in name:
+        print(f"Hello {n}!")
+
+
+@app.command()
+def hello_all_args(names: list[str] = typer.Argument(["World"])) -> None:
     for name in names:
         print(f"Hello {name}!")
 
@@ -108,8 +114,26 @@ def test_enum_choice_missing_message() -> None:
     assert "morty" in result.output
 
 
-def test_variadic_argument_empty() -> None:
-    result = runner.invoke(app, ["hello-all"])
+def test_list() -> None:
+    result = runner.invoke(app, ["hello-all-options", "--name", "Rick", "--name", "Morty"])
+    assert result.exit_code == 0
+    assert "Hello World!" not in result.output
+    assert "Hello Rick!" in result.output
+    assert "Hello Morty!" in result.output
+
+    result = runner.invoke(app, ["hello-all-args", "Rick", "Morty"])
+    assert result.exit_code == 0
+    assert "Hello World!" not in result.output
+    assert "Hello Rick!" in result.output
+    assert "Hello Morty!" in result.output
+
+
+def test_list_empty() -> None:
+    result = runner.invoke(app, ["hello-all-args"])
+    assert result.exit_code == 0
+    assert "Hello World!" in result.output
+
+    result = runner.invoke(app, ["hello-all-options"])
     assert result.exit_code == 0
     assert "Hello World!" in result.output
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -31,7 +31,15 @@ def hello_no_choices(
 
 
 @app.command()
-def hello_all(names: list[str] = typer.Argument(["World"], envvar="NAMES")) -> None:
+def hello_all(names: list[str] = typer.Argument(["World"])) -> None:
+    for name in names:
+        print(f"Hello {name}!")
+
+
+@app.command()
+def hello_all_envvar(
+    names: list[str] = typer.Argument(["World"], envvar="NAMES"),
+) -> None:
     for name in names:
         print(f"Hello {name}!")
 
@@ -100,19 +108,23 @@ def test_enum_choice_missing_message() -> None:
     assert "morty" in result.output
 
 
-def test_split_envvar_value(monkeypatch) -> None:
-    # This will use split_envvar_value to produce two strings from the envvar
-    monkeypatch.setenv("NAMES", "Rick   Morty")
-    result = runner.invoke(app, ["hello-all"])
-    assert result.exit_code == 0
-    assert "Hello Rick!" in result.output
-    assert "Hello Morty!" in result.output
-
-
 def test_variadic_argument_empty() -> None:
     result = runner.invoke(app, ["hello-all"])
     assert result.exit_code == 0
     assert "Hello World!" in result.output
+
+    result = runner.invoke(app, ["hello-all-envvar"])
+    assert result.exit_code == 0
+    assert "Hello World!" in result.output
+
+
+def test_split_envvar_value(monkeypatch) -> None:
+    # This will use split_envvar_value to produce two strings from the envvar
+    monkeypatch.setenv("NAMES", "Rick   Morty")
+    result = runner.invoke(app, ["hello-all-envvar"])
+    assert result.exit_code == 0
+    assert "Hello Rick!" in result.output
+    assert "Hello Morty!" in result.output
 
 
 def test_list_pair() -> None:

--- a/typer/_click/parser.py
+++ b/typer/_click/parser.py
@@ -187,9 +187,9 @@ class _Argument:
                     f"Argument {self.dest!r} takes {self.nargs} values."
                 )
 
-        if self.nargs == -1 and self.obj.envvar is not None and value == ():
-            # Replace empty tuple with None so that a value from the
-            # environment may be tried.
+        if self.nargs == -1 and value == ():
+            # Replace empty tuple with None so regular default resolution
+            # (env var, default map, and parameter default) can be tried.
             value = None
 
         state.opts[self.dest] = value  # type: ignore


### PR DESCRIPTION
## Pull Request

Discussion: https://github.com/fastapi/typer/discussions/1811, reported by @tchervychek 🙏 

## Description

Typer 0.26.0 introduced a regression with respect to using the default of a `List` argument. The only test we had related to this had an envvar setting, obscuring the bug.

Commit that caused this issue was attempting to fix things after cleaning up `UNSET`: https://github.com/svlandeg/typer/commit/cc485f636c75830313eacb31aa03fbbfbc111743 😞 

For good measure, I also added a test for the default of a list option, though this was working fine on `master`. Still, can't hurt to extend the test suite a little.

## AI Disclaimer

Used Cursor for quick diagnostic, but reviewed and written everything myself.

## Checklist

- [x] I added tests for the change.
- [x]  The new or updated tests fail on the main branch and pass on this PR.
- [x] Coverage stays at 100%.
