### PR TITLE
docs: fix undefined variable in Option default docstring example

### DIFF
--- a/typer/params.py
+++ b/typer/params.py
@@ -162,7 +162,7 @@ def Option(
             ```
             @app.command()
             def main(network: Annotated[str, typer.Option()] = "CNN"):
-                print(f"Hello {name}!")
+                print(f"Training neural network of type: {network}")
             ```
 
             You can also use `...` ([Ellipsis](https://docs.python.org/3/library/constants.html#Ellipsis)) as the "default" value to clarify that this is a required CLI option.


### PR DESCRIPTION
The docstring for the `default` parameter of `typer.Option` shows two equivalent examples. The deprecated-style example defines a `network` parameter and prints `{network}`, but the recommended `Annotated`-style example below it keeps the `network` parameter while printing the undefined variable `{name}`, which would raise a `NameError` if run. This corrects the `Annotated` example to print `{network}`, making the two examples consistent with each other and matching the equivalent examples in the `Argument` docstring.