### PR TITLE
🐛 Fix formatting in `NoSuchOption.format_message()`

### DIFF
--- a/typer/_click/exceptions.py
+++ b/typer/_click/exceptions.py
@@ -197,7 +197,7 @@ class NoSuchOption(UsageError):
             return self.message
 
         possibility_str = ", ".join(sorted(self.possibilities))
-        suggest = (f"(Possible options: {possibility_str})",)
+        suggest = f"(Possible options: {possibility_str})"
         return f"{self.message} {suggest}"
 
 


### PR DESCRIPTION
## Pull Request

Discussion: https://github.com/fastapi/typer/discussions/1840

## Description

`NoSuchOption.format_message()` in `typer/_click/exceptions.py` produces a tuple
repr in its output instead of a plain string when `possibilities` is non-empty.

**Current output:**
`Error: No such option: --fooo ('(Possible options: --foo)',)`

**Expected output:**
`Error: No such option: --fooo (Possible options: --foo)`

## Checklist

- [x] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
