### PR TITLE
optimize TyperGroup.list_commands

### DIFF
--- a/typer/core.py
+++ b/typer/core.py
@@ -1214,4 +1214,4 @@ class TyperGroup(_click.Command):
 
     def list_commands(self, ctx: _click.Context) -> list[str]:
         """Returns a list of subcommand names, maintaining the original order of creation (cf Issue #933)"""
-        return [n for n, c in self.commands.items()]
+        return list(self.commands)


### PR DESCRIPTION
## Pull Request

<!--
Please start with a GitHub Discussion.

Once a team member asks you to open a PR, create it and link the discussion here.

Obvious typo fixes can be made in a PR without starting a discussion.
-->

Discussion: <!-- Link to the GitHub Discussion -->

## Description

There is a much more optimized way of going about listing commands from a dictionary and calling `list()` directly from a dictionary will just extract the keys as usual.

## AI Disclaimer

<!-- If using AI, write here the prompt and model used -->

<details>
<summary>AI transcript</summary>

<!-- Paste here the entire AI transcript -->

</details>

## Checklist

- [ ] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
