### PR TITLE
📝 Update docs badges: remove Publish badge, it doesn't give extra information

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@
 <a href="https://github.com/fastapi/typer/actions?query=workflow%3ATest+event%3Apush+branch%3Amaster">
     <img src="https://github.com/fastapi/typer/actions/workflows/test.yml/badge.svg?event=push&branch=master" alt="Test">
 </a>
-<a href="https://github.com/fastapi/typer/actions?query=workflow%3APublish">
-    <img src="https://github.com/fastapi/typer/workflows/Publish/badge.svg" alt="Publish">
-</a>
 <a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/fastapi/typer">
     <img src="https://coverage-badge.samuelcolvin.workers.dev/fastapi/typer.svg" alt="Coverage">
 <a href="https://pypi.org/project/typer">

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,9 +17,6 @@
 <a href="https://github.com/fastapi/typer/actions?query=workflow%3ATest+event%3Apush+branch%3Amaster">
     <img src="https://github.com/fastapi/typer/actions/workflows/test.yml/badge.svg?event=push&branch=master" alt="Test">
 </a>
-<a href="https://github.com/fastapi/typer/actions?query=workflow%3APublish">
-    <img src="https://github.com/fastapi/typer/workflows/Publish/badge.svg" alt="Publish">
-</a>
 <a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/fastapi/typer">
     <img src="https://coverage-badge.samuelcolvin.workers.dev/fastapi/typer.svg" alt="Coverage">
 <a href="https://pypi.org/project/typer">


### PR DESCRIPTION
## Summary
- Remove the Publish workflow badge from the docs badges.
- Keep the remaining status, coverage, and package badges unchanged.

## AI Disclaimer
Codex GPT 5.5, reviewed by hand.
