### PR TITLE
Name the zsh completion function _<prog> so autoload works

### DIFF
--- a/tests/test_completion/test_completion.py
+++ b/tests/test_completion/test_completion.py
@@ -119,9 +119,10 @@ def test_completion_source_zsh():
             "_TUTORIAL001_PY310.PY_COMPLETE": "source_zsh",
         },
     )
-    assert (
-        "compdef _tutorial001_py310py_completion tutorial001_py310.py" in result.stdout
-    )
+    assert "compdef _tutorial001_py310py tutorial001_py310.py" in result.stdout
+    # #1864: the function name must match the autoloaded filename (_<prog>), so
+    # it must not carry the old `_completion` suffix.
+    assert "_tutorial001_py310py_completion" not in result.stdout
 
 
 def test_completion_source_fish():

--- a/tests/test_completion/test_completion_install.py
+++ b/tests/test_completion/test_completion_install.py
@@ -104,10 +104,10 @@ def test_completion_install_zsh():
     assert install_source_path.is_file()
     install_content = install_source_path.read_text()
     install_source_path.unlink()
-    assert (
-        "compdef _tutorial001_py310py_completion tutorial001_py310.py"
-        in install_content
-    )
+    assert "compdef _tutorial001_py310py tutorial001_py310.py" in install_content
+    # #1864: the function name must match the autoloaded filename (_<prog>), so
+    # it must not carry the old `_completion` suffix.
+    assert "_tutorial001_py310py_completion" not in install_content
 
 
 @requires_completion_permission

--- a/tests/test_completion/test_completion_show.py
+++ b/tests/test_completion/test_completion_show.py
@@ -68,9 +68,10 @@ def test_completion_source_zsh():
             "_TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION": "True",
         },
     )
-    assert (
-        "compdef _tutorial001_py310py_completion tutorial001_py310.py" in result.stdout
-    )
+    assert "compdef _tutorial001_py310py tutorial001_py310.py" in result.stdout
+    # #1864: the function name must match the autoloaded filename (_<prog>), so
+    # it must not carry the old `_completion` suffix.
+    assert "_tutorial001_py310py_completion" not in result.stdout
 
 
 def test_completion_source_fish():

--- a/typer/_completion_classes.py
+++ b/typer/_completion_classes.py
@@ -102,6 +102,10 @@ class ZshComplete(ShellComplete):
     def source_vars(self) -> dict[str, Any]:
         return {
             "complete_func": self.func_name,
+            # zsh autoloads a completion from a file named after the command
+            # (e.g. `_prog`), and the function it defines must match that
+            # filename, so drop the `_completion` suffix here. See #1864.
+            "zsh_func": self.func_name.removesuffix("_completion"),
             "autocomplete_var": self.complete_var,
             "prog_name": self.prog_name,
         }

--- a/typer/_completion_shared.py
+++ b/typer/_completion_shared.py
@@ -33,11 +33,11 @@ complete -o default -F %(complete_func)s %(prog_name)s
 COMPLETION_SCRIPT_ZSH = """
 #compdef %(prog_name)s
 
-%(complete_func)s() {
+%(zsh_func)s() {
   eval $(env _TYPER_COMPLETE_ARGS="${words[1,$CURRENT]}" %(autocomplete_var)s=complete_zsh %(prog_name)s)
 }
 
-compdef %(complete_func)s %(prog_name)s
+compdef %(zsh_func)s %(prog_name)s
 """
 
 COMPLETION_SCRIPT_FISH = 'complete --command %(prog_name)s --no-files --arguments "(env %(autocomplete_var)s=complete_fish _TYPER_COMPLETE_FISH_ACTION=get-args _TYPER_COMPLETE_ARGS=(commandline -cp) %(prog_name)s)" --condition "env %(autocomplete_var)s=complete_fish _TYPER_COMPLETE_FISH_ACTION=is-args _TYPER_COMPLETE_ARGS=(commandline -cp) %(prog_name)s"'
@@ -86,6 +86,11 @@ def get_completion_script(*, prog_name: str, complete_var: str, shell: str) -> s
         script
         % {
             "complete_func": f"_{cf_name}_completion",
+            # zsh autoloads a completion from a file in $fpath named after the
+            # command (e.g. `_prog`), and the function it defines must match that
+            # filename. Use `_{name}` (not `_{name}_completion`) so the packaged
+            # / autoloaded completion actually registers. See #1864.
+            "zsh_func": f"_{cf_name}",
             "prog_name": prog_name,
             "autocomplete_var": complete_var,
         }


### PR DESCRIPTION
Fixes #1864.

## Problem

zsh autoloads a completion from a file in `$fpath` named after the command (say `_prog`), and the autoload convention requires the function that file defines to match the filename. Typer generated the function as `_<prog>_completion`, so when it's loaded that way the completion silently fails. zsh autoloads `_prog`, finds no `_prog` function, and falls back to filename completion instead of command completion:

```zsh
#compdef hf
_hf_completion() { ... }     # autoloaded file is named "_hf", so there's no "_hf" function
compdef _hf_completion hf
```

It hits two paths. Packaging (`prog --show-completion=zsh > $fpath/_hf`), which is what the issue reports. And `--install-completion`, which writes the script to `~/.zfunc/_<prog>` and adds `fpath+=~/.zfunc; autoload -Uz compinit`, so the same autoload route.

## Fix

Generate `_<prog>` instead of `_<prog>_completion`. The `#compdef`/`compdef` lines already register the completion, so the `_completion` suffix wasn't buying anything, and dropping it makes the function name match the autoloaded filename:

```zsh
#compdef hf
_hf() { ... }
compdef _hf hf
```

The zsh script is rendered in two places, `get_completion_script` (the `--show-completion`/`--install-completion` path) and `ZshComplete.source()` (the `_<PROG>_COMPLETE=source_zsh` runtime path), so I updated both to keep them consistent. It's zsh-only. bash/fish/PowerShell output is unchanged (bash keeps `_<prog>_completion`, which has no filename constraint).

## Tests

Updated the three existing zsh completion assertions (`test_completion.py`, `test_completion_show.py`, `test_completion_install.py`) to expect `_<prog>` and to check the old `_completion` suffix is gone. They pass with the fix and fail without it. Full `tests/test_completion/` suite passes locally (77 passed). `ruff check`/`format` clean.
