### PR TITLE
Expose ClickException and UsageError from the typer namespace

### DIFF
--- a/tests/test_exit_errors.py
+++ b/tests/test_exit_errors.py
@@ -56,3 +56,27 @@ def test_oserror_no_epipe():
 
     result = runner.invoke(app)
     assert result.exit_code == 1
+
+
+def test_click_exception():
+    app = typer.Typer()
+
+    @app.command()
+    def main():
+        raise typer.ClickException("something broke")
+
+    result = runner.invoke(app)
+    assert result.exit_code == 1
+    assert "something broke" in result.output
+
+
+def test_usage_error():
+    app = typer.Typer()
+
+    @app.command()
+    def main():
+        raise typer.UsageError("bad usage")
+
+    result = runner.invoke(app)
+    assert result.exit_code == 2
+    assert "bad usage" in result.output

--- a/typer/__init__.py
+++ b/typer/__init__.py
@@ -7,7 +7,9 @@ from shutil import get_terminal_size as get_terminal_size
 from . import colors as colors
 from ._click.exceptions import Abort as Abort
 from ._click.exceptions import BadParameter as BadParameter
+from ._click.exceptions import ClickException as ClickException
 from ._click.exceptions import Exit as Exit
+from ._click.exceptions import UsageError as UsageError
 from ._click.termui import confirm as confirm
 from ._click.termui import getchar as getchar
 from ._click.termui import progressbar as progressbar


### PR DESCRIPTION
## Summary
Closes #1867.

After vendoring Click in 0.26.0, Typer re-exports several vendored exception types — `typer.BadParameter`, `typer.Abort`, `typer.Exit` — but **not** the general-purpose `ClickException` / `UsageError`. That leaves no public way to raise a concise user-facing CLI error without importing from the private `typer._click` module (which the 0.26.0 vendoring guidance tells users not to do).

## Change
Re-export the two vendored base errors alongside the existing ones, keeping the imports alphabetically ordered:

```python
from ._click.exceptions import ClickException as ClickException
from ._click.exceptions import UsageError as UsageError
```

Apps can now do:

```python
raise typer.ClickException("something broke")   # exit code 1, Typer-rendered
raise typer.UsageError("bad usage")             # exit code 2
```

## Tests
Added `test_click_exception` and `test_usage_error` to `tests/test_exit_errors.py` asserting the exit codes (1 and 2) and that the message reaches the output.

Verified locally: `pytest tests/test_exit_errors.py` → **6 passed**; `ruff check` clean.