### PR TITLE
fix: hide INTEGER from help for count=True options (closes #1869)

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -377,3 +377,31 @@ def test_nargs_default_map():
     result = runner.invoke(app, [], default_map={"names": "not-a-list"})
     assert result.exit_code == 2
     assert "Invalid value" in result.output
+
+
+def test_count_option_help_no_metavar() -> None:
+    """Regression test for https://github.com/fastapi/typer/issues/1869.
+
+    count=True options should not show INTEGER in help since they don't take a value.
+    """
+    app = typer.Typer()
+
+    @app.command()
+    def main(verbose: int = typer.Option(0, count=True)):
+        """Count verbosity."""
+        typer.echo(f"verbose={verbose}")
+
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    # The help must not show INTEGER for a count option
+    assert "INTEGER" not in result.output
+    assert "--verbose" in result.output
+
+    # Behaviour: --verbose increments
+    assert runner.invoke(app, ["--verbose"]).exit_code == 0
+
+    # Behaviour: --verbose 3 is rejected (count doesn't accept a value)
+    result = runner.invoke(app, ["--verbose", "3"])
+    assert result.exit_code == 2
+    assert "unexpected extra argument" in result.output
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -404,4 +404,3 @@ def test_count_option_help_no_metavar() -> None:
     result = runner.invoke(app, ["--verbose", "3"])
     assert result.exit_code == 2
     assert "unexpected extra argument" in result.output
-

--- a/typer/core.py
+++ b/typer/core.py
@@ -743,6 +743,8 @@ class TyperOption(_click.Parameter):
         return _extract_default_help_str(self, ctx=ctx)
 
     def make_metavar(self, ctx: _click.Context) -> str:
+        if self.count:
+            return ""
         return super().make_metavar(ctx=ctx)
 
     def get_help_record(self, ctx: _click.Context) -> tuple[str, str] | None:

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -397,9 +397,7 @@ def _print_options_panel(
         types_data = Text(style=STYLE_TYPES, overflow="fold")
 
         # Fetch type
-        is_count_option: bool = (
-            isinstance(param, TyperOption) and param.count
-        )
+        is_count_option: bool = isinstance(param, TyperOption) and param.count
         if metavar_type and metavar_type != "BOOLEAN":
             types_data.append(metavar_type)
         elif not is_count_option:

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -397,9 +397,12 @@ def _print_options_panel(
         types_data = Text(style=STYLE_TYPES, overflow="fold")
 
         # Fetch type
+        is_count_option: bool = (
+            isinstance(param, TyperOption) and param.count
+        )
         if metavar_type and metavar_type != "BOOLEAN":
             types_data.append(metavar_type)
-        else:
+        elif not is_count_option:
             type_str = param.type.name.upper()
             if type_str != "BOOLEAN":
                 types_data.append(type_str)


### PR DESCRIPTION
## Pull Request

**Discussion:** https://github.com/fastapi/typer/issues/1869

## Description

Fixed #1869 — `count=True` options were incorrectly showing `INTEGER` in the help text, making it look like they take a value (e.g. `--verbose 3`), when they actually work as flag-like counters (e.g. `--verbose --verbose`).

Two small changes:

- **`typer/core.py`**: `TyperOption.make_metavar()` now returns `""` for `count=True` options, matching how Click handles count internally.
- **`typer/rich_utils.py`**: `_print_options_panel()` now skips appending the type name (e.g. `INTEGER RANGE`) for count options.

**Before:** `--verbose   INTEGER  [default: 0]`  
**After:** `--verbose   [default: 0]`

## AI Disclaimer
Review with Claude Opus 4.6

## Checklist

- [x] This PR links to a GitHub Discussion for the proposed code change.
- [x] I added tests for the change.
- [x] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.*
- [ ] The documentation explains the change if needed.

*Coverage note: `test_others.py::test_atomic_write_example` has a pre-existing failure unrelated to this change. All other tests pass (38/38 in `test_core.py` and `test_rich_utils.py`).