### PR TITLE
🔧 Set Dependabot schedule interval to "monthly"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
       default-days: 7
     commit-message:
@@ -21,7 +21,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
       default-days: 7
     commit-message:
@@ -51,7 +51,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/scripts/docker"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
       default-days: 7
     commit-message:
@@ -63,7 +63,7 @@ updates:
   - package-ecosystem: "docker-compose"
     directory: "/scripts/docker"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
       default-days: 7
     commit-message:


### PR DESCRIPTION
Weekly dependency updates are too noisy and not needed.

Don't update interval for `pre-commit` ecosystem as we decided to remove it.
