### PR TITLE
🏷️ Make `Parameter.name` typed as `str` instead of `str | None`

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -55,9 +55,9 @@ def test_parameter_nargs_gt_1() -> None:
 
 
 def test_parameter_constructor() -> None:
-    # no param_decl and expose_value is False: sets name to None
+    # no param_decl and expose_value is False: sets name to ""
     arg = TyperArgument(param_decls=[], expose_value=False)
-    assert arg.name is None
+    assert arg.name == ""
     assert arg.opts == []
     assert arg.secondary_opts == []
 
@@ -77,9 +77,9 @@ def test_parameter_constructor() -> None:
     with pytest.raises(ValueError, match="cannot use the same flag for true/false"):
         TyperOption(param_decls=["flag", "--flag/--flag"], required=False, is_flag=True)
 
-    # inferred name is not a valid identifier: sets name to None
+    # inferred name is not a valid identifier: sets name to ""
     unnamed_option = TyperOption(param_decls=["--123"], required=False)
-    assert unnamed_option.name is None
+    assert unnamed_option.name == ""
 
     # no param_decl and prompt=True: raises
     with pytest.raises(TypeError, match="'name' is required with 'prompt=True'."):

--- a/typer/_click/core.py
+++ b/typer/_click/core.py
@@ -767,7 +767,7 @@ class Command(ABC):
                     or param.hidden
                     or (
                         not param.multiple
-                        and ctx.get_parameter_source(param.name)  # type: ignore
+                        and ctx.get_parameter_source(param.name)
                         is ParameterSource.COMMANDLINE
                     )
                 ):
@@ -834,7 +834,7 @@ class Parameter(ABC):
         ]
         | None = None,
     ) -> None:
-        self.name: str | None
+        self.name: str
         self.opts: list[str]
         self.secondary_opts: list[str]
         self.name, self.opts, self.secondary_opts = self._parse_decls(
@@ -867,7 +867,7 @@ class Parameter(ABC):
     @abstractmethod
     def _parse_decls(
         self, decls: Sequence[str], expose_value: bool
-    ) -> tuple[str | None, list[str], list[str]]:
+    ) -> tuple[str, list[str], list[str]]:
         pass  # pragma: no cover
 
     @property
@@ -875,7 +875,6 @@ class Parameter(ABC):
         """Returns the human readable name of this parameter.  This is the
         same as the name for options, but the metavar for arguments.
         """
-        assert self.name is not None, "self.name should be set"
         return self.name
 
     def make_metavar(self, ctx: Context) -> str:
@@ -904,7 +903,7 @@ class Parameter(ABC):
         self, ctx: Context, call: bool = True
     ) -> Any | Callable[[], Any] | None:
         """Get the default for the parameter"""
-        value = ctx.lookup_default(self.name, call=False)  # type: ignore
+        value = ctx.lookup_default(self.name, call=False)
 
         if value is None:
             value = self.default
@@ -921,7 +920,7 @@ class Parameter(ABC):
     def consume_value(
         self, ctx: Context, opts: Mapping[str, Any]
     ) -> tuple[Any, ParameterSource]:
-        value = opts.get(self.name)  # type: ignore
+        value = opts.get(self.name)
         source = ParameterSource.COMMANDLINE
 
         if value is None:
@@ -929,7 +928,7 @@ class Parameter(ABC):
             source = ParameterSource.ENVIRONMENT
 
         if value is None:
-            value = ctx.lookup_default(self.name)  # type: ignore
+            value = ctx.lookup_default(self.name)
             source = ParameterSource.DEFAULT_MAP
 
         if value is None:
@@ -1064,7 +1063,7 @@ class Parameter(ABC):
         with augment_usage_errors(ctx, param=self):
             value, source = self.consume_value(ctx, opts)
 
-            ctx.set_parameter_source(self.name, source)  # type: ignore
+            ctx.set_parameter_source(self.name, source)
 
             # Process the value through the parameter's type.
             try:
@@ -1075,7 +1074,7 @@ class Parameter(ABC):
                 value = None
 
         if self.expose_value:
-            ctx.params[self.name] = value  # type: ignore
+            ctx.params[self.name] = value
 
         return value, args
 

--- a/typer/_click/shell_completion.py
+++ b/typer/_click/shell_completion.py
@@ -179,8 +179,6 @@ def _is_incomplete_argument(ctx: Context, param: Parameter) -> bool:
     if not isinstance(param, TyperArgument):
         return False
 
-    assert param.name is not None
-    # Will be None if expose_value is False.
     value = ctx.params.get(param.name)
     return (
         param.nargs == -1

--- a/typer/core.py
+++ b/typer/core.py
@@ -302,7 +302,6 @@ class TyperArgument(_click.core.Parameter):
     def human_readable_name(self) -> str:
         if self.metavar is not None:
             return self.metavar
-        assert self.name is not None, "self.name or self.metavar should be set"
         return self.name.upper()
 
     def _get_default_string(
@@ -403,10 +402,10 @@ class TyperArgument(_click.core.Parameter):
 
     def _parse_decls(
         self, decls: Sequence[str], expose_value: bool
-    ) -> tuple[str | None, list[str], list[str]]:
+    ) -> tuple[str, list[str], list[str]]:
         if not decls:
             if not expose_value:
-                return None, [], []
+                return "", [], []
             raise TypeError("Argument is marked as exposed, but does not have a name.")
         if len(decls) == 1:
             name = arg = decls[0]
@@ -491,7 +490,7 @@ class TyperOption(_click.Parameter):
         )
 
         if prompt is True:
-            if self.name is None:
+            if not self.name:
                 raise TypeError("'name' is required with 'prompt=True'.")
 
             prompt_text: str | None = self.name.replace("_", " ").capitalize()
@@ -542,7 +541,7 @@ class TyperOption(_click.Parameter):
 
     def _parse_decls(
         self, decls: Sequence[str], expose_value: bool
-    ) -> tuple[str | None, list[str], list[str]]:
+    ) -> tuple[str, list[str], list[str]]:
         opts = []
         secondary_opts = []
         name = None
@@ -579,7 +578,7 @@ class TyperOption(_click.Parameter):
             if not name.isidentifier():
                 name = None
 
-        return name, opts, secondary_opts
+        return name or "", opts, secondary_opts
 
     def add_to_parser(self, parser: _OptionParser, ctx: _click.Context) -> None:
         if self.multiple:
@@ -685,11 +684,7 @@ class TyperOption(_click.Parameter):
         if rv is not None:
             return rv
 
-        if (
-            self.allow_from_autoenv
-            and ctx.auto_envvar_prefix is not None
-            and self.name is not None
-        ):
+        if self.allow_from_autoenv and ctx.auto_envvar_prefix is not None and self.name:
             envvar = f"{ctx.auto_envvar_prefix}_{self.name.upper()}"
             rv = os.environ.get(envvar)
 
@@ -782,7 +777,7 @@ class TyperOption(_click.Parameter):
                 if (
                     self.allow_from_autoenv
                     and ctx.auto_envvar_prefix is not None
-                    and self.name is not None
+                    and self.name
                 ):
                     envvar = f"{ctx.auto_envvar_prefix}_{self.name.upper()}"
 

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -259,7 +259,7 @@ def _get_parameter_help(
         if (
             getattr(param, "allow_from_autoenv", None)
             and getattr(ctx, "auto_envvar_prefix", None) is not None
-            and param.name is not None
+            and param.name
         ):
             envvar = f"{ctx.auto_envvar_prefix}_{param.name.upper()}"
     if envvar is not None:


### PR DESCRIPTION
## Description

On attempt to upgrade `ty` to 0.0.48+ it gives:

```
warning[unused-type-ignore-comment]: Unused blanket `type: ignore` directive
   --> typer/_click/core.py:924:38
    |
924 |         value = opts.get(self.name)  # type: ignore
    |                                      ^^^^^^^^^^^^^^
    |
help: Remove the unused suppression comment
921 |     def consume_value(
922 |         self, ctx: Context, opts: Mapping[str, Any]
923 |     ) -> tuple[Any, ParameterSource]:
    -         value = opts.get(self.name)  # type: ignore
924 +         value = opts.get(self.name)
925 |         source = ParameterSource.COMMANDLINE
926 |
927 |         if value is None:
```

This is obviously false-negative. `self.name` is typed as `str | None`, so it can't be passed to `opts.get()` that accepts `str`.

While investigatig this I found out that Click recently updated the typing of `Parameter.name` to just `str`. See PR https://github.com/pallets/click/pull/2805

So, why don't we do the same?


## AI Disclaimer

Implemented with the help of `Claude Opus 4.8 (1M context)`, then reviewed manually

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.

(typing only, no tests needed)