### PR TITLE
⬆️ Update latest-changes to 0.6.1

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -39,7 +39,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true' }}
         with:
           limit-access-to-actor: true
-      - uses: tiangolo/latest-changes@43f19d63faf0edfed2cc482122bcfbc4a637cf02 # 0.6.0
+      - uses: tiangolo/latest-changes@c9b73efbc8992ef1a401e4235ea307a8ca8a724b # 0.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest_changes_file: docs/release-notes.md


### PR DESCRIPTION
## Description

Update the `tiangolo/latest-changes` GitHub Action pin from `0.6.0` to `0.6.1`.

This picks up the action runtime fix so the Docker action uses its baked-in virtual environment instead of letting `uv run` inspect the consumer repository's Python version configuration.

## Checks

- `git diff --check -- .github/workflows/latest-changes.yml`
- `yq '.jobs.latest-changes.steps[] | select(.uses == "tiangolo/latest-changes@c9b73efbc8992ef1a401e4235ea307a8ca8a724b")' .github/workflows/latest-changes.yml`
- `prek` hooks during commit: YAML, typos, mypy, ty, and zizmor passed

## AI Disclaimer

Using Codex with GPT-5. Reviewed manually.