### PR TITLE
Write generated docs as UTF-8 in `typer ... utils docs --output`

### DIFF
--- a/tests/test_cli/test_doc.py
+++ b/tests/test_cli/test_doc.py
@@ -86,6 +86,56 @@ def test_doc_title_output(tmp_path: Path):
     assert "Docs saved to:" in result.stdout
 
 
+def test_doc_output_non_ascii(tmp_path: Path):
+    # Docs must be written as UTF-8 regardless of the platform's default
+    # encoding, otherwise non-ASCII help (e.g. emojis) crashes with a
+    # UnicodeEncodeError on interpreters where the locale encoding is not UTF-8
+    # (e.g. cp1252 on Windows).
+    app_file: Path = tmp_path / "emoji_app.py"
+    app_file.write_text(
+        "import typer\n"
+        "app = typer.Typer()\n\n\n"
+        "@app.command()\n"
+        "def hello(name: str):\n"
+        '    """Say hello 👋 to someone."""\n'
+        "    print(name)\n",
+        encoding="utf-8",
+    )
+    out_file: Path = tmp_path / "out.md"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            "-m",
+            "typer",
+            str(app_file),
+            "utils",
+            "docs",
+            "--name",
+            "emoji",
+            "--output",
+            str(out_file),
+        ],
+        capture_output=True,
+        encoding="utf-8",
+        # Force a non-UTF-8 locale so the write path fails on the old behavior
+        # on any platform (not only Windows).
+        env={
+            **os.environ,
+            "PYTHONUTF8": "0",
+            "LC_ALL": "C",
+            "LANG": "C",
+            "PYTHONIOENCODING": "utf-8",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    written_docs = out_file.read_text(encoding="utf-8")
+    assert "👋" in written_docs
+    assert "Docs saved to:" in result.stdout
+
+
 def test_doc_no_rich():
     result = subprocess.run(
         [

--- a/tests/test_cli/test_doc.py
+++ b/tests/test_cli/test_doc.py
@@ -124,9 +124,12 @@ def test_doc_output_non_ascii(tmp_path: Path):
         # on any platform (not only Windows).
         env={
             **os.environ,
-            "PYTHONUTF8": "0",
+            # LC_ALL forces a non-UTF-8 locale (the write path would otherwise
+            # use UTF-8 on most CI); PYTHONUTF8=0 keeps it non-UTF-8 on 3.15+
+            # where UTF-8 mode is on by default; PYTHONIOENCODING lets us capture
+            # the subprocess output cleanly when it fails.
             "LC_ALL": "C",
-            "LANG": "C",
+            "PYTHONUTF8": "0",
             "PYTHONIOENCODING": "utf-8",
         },
     )

--- a/typer/cli.py
+++ b/typer/cli.py
@@ -307,7 +307,7 @@ def docs(
     docs = get_docs_for_click(obj=click_obj, ctx=ctx, name=name, title=title)
     clean_docs = f"{docs.strip()}\n"
     if output:
-        output.write_text(clean_docs)
+        output.write_text(clean_docs, encoding="utf-8")
         typer.echo(f"Docs saved to: {output}")
     else:
         typer.echo(clean_docs)


### PR DESCRIPTION
Discussion: https://github.com/fastapi/typer/discussions/1882

## Description

`typer <app> utils docs --output FILE` writes the generated Markdown with `Path.write_text(clean_docs)`, which uses the platform's default encoding. When the CLI's help contains non-ASCII characters (emojis are common in Typer/Rich apps) this raises `UnicodeEncodeError` on interpreters whose locale encoding isn't UTF-8 (for example cp1252 on Windows).

Reproduction:

```python
# emoji_app.py
import typer

app = typer.Typer()


@app.command()
def hello(name: str):
    """Say hello 👋 to someone."""
```

```console
$ typer emoji_app utils docs --output out.md
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f44b' ...
```

This writes the file as UTF-8, which matches how the docs are read back in the tests (`read_text(encoding="utf-8")`).

I also added a regression test that forces a non-UTF-8 locale (`LC_ALL=C`, `PYTHONUTF8=0`) so it fails on the old behavior on any platform, not just Windows.