### PR TITLE
fix: hide INTEGER from help for count=True options (#1869)

### DIFF
--- a/typer/core.py
+++ b/typer/core.py
@@ -743,6 +743,8 @@ class TyperOption(_click.Parameter):
         return _extract_default_help_str(self, ctx=ctx)
 
     def make_metavar(self, ctx: _click.Context) -> str:
+        if getattr(self, "count", False):
+            return ""
         return super().make_metavar(ctx=ctx)
 
     def get_help_record(self, ctx: _click.Context) -> tuple[str, str] | None:

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -397,7 +397,10 @@ def _print_options_panel(
         types_data = Text(style=STYLE_TYPES, overflow="fold")
 
         # Fetch type
-        if metavar_type and metavar_type != "BOOLEAN":
+        is_count = getattr(param, "count", False)
+        if is_count:
+            pass
+        elif metavar_type and metavar_type != "BOOLEAN":
             types_data.append(metavar_type)
         else:
             type_str = param.type.name.upper()


### PR DESCRIPTION
## Pull Request

Discussion: https://github.com/fastapi/typer/issues/1869

## Description

Fixes #1869 — `count=True` options were incorrectly showing `INTEGER` in the help text, making it look like they take a value (e.g. `--verbose 3`), when they actually work as flag-like counters.

This PR introduces two small changes:
- **`typer/core.py`**: `TyperOption.make_metavar()` now returns `""` for `count=True` options.
- **`typer/rich_utils.py`**: `_print_options_panel()` now skips appending the type name (e.g. `INTEGER`) for count options.

## AI Disclaimer

Used Gemini 3.1 Pro (via Antigravity IDE) to assist in analyzing the issue and modifying the respective `make_metavar` and `_print_options_panel` logic.

<details>
<summary>AI transcript</summary>

(Optional: You can copy and paste our conversation here if you want to be completely transparent, otherwise you can leave it blank or remove this tag)

</details>

## Checklist

- [x] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
