### PR TITLE
fix(docs): prevent scroll-to-top on restart/fast buttons in termynal.js

### DIFF
--- a/docs/js/termynal.js
+++ b/docs/js/termynal.js
@@ -133,7 +133,7 @@ class Termynal {
             this.container.innerHTML = ''
             this.init()
         }
-        restart.href = '#'
+        restart.href = "javascript:void(0)"
         restart.setAttribute('data-terminal-control', '')
         restart.innerHTML = "restart ↻"
         return restart
@@ -147,7 +147,7 @@ class Termynal {
             this.typeDelay = 0
             this.startDelay = 0
         }
-        finish.href = '#'
+        finish.href = "javascript:void(0)"
         finish.setAttribute('data-terminal-control', '')
         finish.innerHTML = "fast →"
         this.finishElement = finish


### PR DESCRIPTION
## Description

Fixes the intermittent scroll-to-top when clicking the "restart" / "fast" controls on the animated terminal blocks in the docs, reported in discussion #1887 (credit to the reporter for the find and the FastAPI-vs-Typer comparison).

Root cause: both controls are anchors with `href='#'`. Although the click handlers call `e.preventDefault()`, navigation to `#` can still slip through (e.g. when restart wipes `container.innerHTML` mid-event), jumping the page to the top, which matches the "sometimes happens, sometimes doesn't" behavior described in the report.

This is a 1:1 port of the fix already merged and live on the FastAPI docs: fastapi/fastapi#13714, the same two lines in the same vendored `termynal.js`, using `javascript:void(0)` so the anchor never navigates.

## Verification

- The diff is identical to the upstream FastAPI fix, in production on fastapi.tiangolo.com since Aug 2025; the reporter confirmed the FastAPI docs behave correctly while the Typer docs do not.
- `docs/js/termynal.js` was otherwise already in sync with FastAPI's copy except for these two lines.

Related discussion: #1887

Supersedes #1888 (closed to resubmit with a cleaner commit).