### PR TITLE
Fix typos in comments: reusing, in between

### DIFF
--- a/typer/core.py
+++ b/typer/core.py
@@ -344,7 +344,7 @@ class TyperArgument(_click.core.Parameter):
                 extra.append(f"env var: {var_str}")
 
         # Typer override:
-        # Extracted to _extract_default_help_str() to allow re-using it in rich_utils
+        # Extracted to _extract_default_help_str() to allow reusing it in rich_utils
         default_value = self._extract_default_help_str(ctx=ctx)
         # Typer override end
 
@@ -354,7 +354,7 @@ class TyperArgument(_click.core.Parameter):
             default_value is not None and (self.show_default or ctx.show_default)
         ):
             # Typer override:
-            # Extracted to _get_default_string() to allow re-using it in rich_utils
+            # Extracted to _get_default_string() to allow reusing it in rich_utils
             default_string = self._get_default_string(
                 ctx=ctx,
                 show_default_is_str=show_default_is_str,
@@ -795,7 +795,7 @@ class TyperOption(_click.Parameter):
                 extra.append(_("env var: {var}").format(var=var_str))
 
         # Typer override:
-        # Extracted to _extract_default() to allow re-using it in rich_utils
+        # Extracted to _extract_default() to allow reusing it in rich_utils
         default_value = self._extract_default_help_str(ctx=ctx)
         # Typer override end
 
@@ -805,7 +805,7 @@ class TyperOption(_click.Parameter):
             default_value is not None and (self.show_default or ctx.show_default)
         ):
             # Typer override:
-            # Extracted to _get_default_string() to allow re-using it in rich_utils
+            # Extracted to _get_default_string() to allow reusing it in rich_utils
             default_string = self._get_default_string(
                 ctx=ctx,
                 show_default_is_str=show_default_is_str,

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -220,7 +220,7 @@ def _get_help_text(
 
     # Get remaining lines, remove single line breaks and format as dim
     if remaining_paragraphs:
-        # Add a newline inbetween the header and the remaining paragraphs
+        # Add a newline in between the header and the remaining paragraphs
         yield Text("")
         # Join with double linebreaks for markdown and Rich markup
         remaining_lines = "\n\n".join(remaining_paragraphs)


### PR DESCRIPTION
Fix two spelling mistakes found by codespell in Python source files.

## Changes

- `typer/core.py`: replace "re-using" with "reusing" in four comment lines
- `typer/rich_utils.py`: replace "inbetween" with "in between" in one comment line

These are comment-only changes with no functional impact.