### PR TITLE
Exclude hidden commands from command suggestions

### DIFF
--- a/tests/test_suggest_commands.py
+++ b/tests/test_suggest_commands.py
@@ -1,5 +1,9 @@
+import pytest
 import typer
+import typer.core
 from typer.testing import CliRunner
+
+from tests.utils import needs_rich
 
 runner = CliRunner()
 
@@ -96,3 +100,35 @@ def test_typo_suggestion_disabled():
     assert result.exit_code != 0
     assert "No such command" in result.output
     assert "Did you mean" not in result.output
+
+
+@pytest.mark.parametrize(
+    "use_rich",
+    [
+        pytest.param(False),
+        pytest.param(True, marks=needs_rich),
+    ],
+)
+def test_typo_suggestion_excludes_hidden_commands(
+    monkeypatch: pytest.MonkeyPatch, use_rich: bool
+) -> None:
+    monkeypatch.setattr(typer.core, "HAS_RICH", use_rich)
+    app = typer.Typer()
+
+    @app.command()
+    def secret_agent():  # pragma: no cover
+        typer.echo("Visible command")
+
+    @app.command(hidden=True)
+    def secret_admin():
+        typer.echo("Hidden command")
+
+    result = runner.invoke(app, ["secret-admi"])
+    assert result.exit_code != 0
+    assert "No such command" in result.output
+    assert "'secret-agent'" in result.output
+    assert "'secret-admin'" not in result.output
+
+    result = runner.invoke(app, ["secret-admin"])
+    assert result.exit_code == 0
+    assert "Hidden command" in result.output

--- a/typer/core.py
+++ b/typer/core.py
@@ -1181,7 +1181,11 @@ class TyperGroup(_click.Command):
             return self._click_resolve_command(ctx, args)
         except _click.exceptions.UsageError as e:
             if self.suggest_commands:
-                available_commands = list(self.commands.keys())
+                available_commands = [
+                    name
+                    for name, command in self.commands.items()
+                    if not command.hidden
+                ]
                 if available_commands and args:
                     typo = args[0]
                     matches = get_close_matches(typo, available_commands)


### PR DESCRIPTION
## Summary

Hidden commands were included when Typer generated typo suggestions, exposing command names intentionally omitted from help output.

Suggestion candidates are now filtered using each command's `hidden` status. Visible-command suggestions remain unchanged, and hidden commands remain directly invokable by their exact names.

## Tests

Added regression coverage for both Rich and plain Click-style error rendering, verifying that:

- hidden commands are not suggested
- visible commands are still suggested
- hidden commands remain directly invokable

## Validation

- `uv run pytest tests/test_suggest_commands.py tests/test_hidden.py tests/test_rich_utils.py -q`
- `uv run bash scripts/lint.sh`
- `env -u NO_COLOR TERM=xterm-256color uv run bash scripts/test.sh`
- `git diff --check`
