### PR TITLE
🐛 Prevent scroll-to-top on restart/fast buttons in the documentation

### DIFF
--- a/docs/js/termynal.js
+++ b/docs/js/termynal.js
@@ -133,7 +133,7 @@ class Termynal {
             this.container.innerHTML = ''
             this.init()
         }
-        restart.href = '#'
+        restart.href = 'javascript:void(0)'
         restart.setAttribute('data-terminal-control', '')
         restart.innerHTML = "restart ↻"
         return restart
@@ -147,7 +147,7 @@ class Termynal {
             this.typeDelay = 0
             this.startDelay = 0
         }
-        finish.href = '#'
+        finish.href = 'javascript:void(0)'
         finish.setAttribute('data-terminal-control', '')
         finish.innerHTML = "fast →"
         this.finishElement = finish


### PR DESCRIPTION
## Pull Request

Discussion: https://github.com/fastapi/typer/discussions/1887

## Description
### Motivation
Upon clicking `fast` or `restart` in terminal widgets within the documentation, one would be forced to the top-of-the-page, which disrupts the user and makes it slightly harder to read documentation (perhaps).

### Solution
This was a previously resolved issue in the FastAPI docs and the fix was proposed in this PR: https://github.com/fastapi/fastapi/pull/13714 - which eventually got merged.

I used the same fix that was merged there, changing `href = #` to rather be `href = javascript:void(0)`, which should keep consistency across the repos.

(I suggest looking at the original FastAPI PR for more technical depth on the solution, which I linked above)

## AI Disclaimer

No AI was used in the process of this PR.


## Checklist

- [X] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [X] Coverage stays at 100%.
- [X] The documentation explains the change if needed.
