### PR TITLE
Fix bash completion for COMP_WORDBREAKS characters like colon

### DIFF
--- a/tests/test_completion/test_completion_bash_wordbreaks.py
+++ b/tests/test_completion/test_completion_bash_wordbreaks.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from ..utils import needs_bash
+from ..utils import needs_bash, skip_if_windows
 from . import colon_example as mod
 
 
@@ -77,6 +77,7 @@ printf '%s\\n' "${{COMPREPLY[@]}}"
     return result.stdout
 
 
+@skip_if_windows
 @needs_bash
 def test_bash_completion_script_handles_comp_wordbreaks_colon() -> None:
     show = subprocess.run(

--- a/tests/test_completion/test_completion_bash_wordbreaks.py
+++ b/tests/test_completion/test_completion_bash_wordbreaks.py
@@ -1,6 +1,6 @@
 import os
+import re
 import shutil
-import stat
 import subprocess
 import sys
 import tempfile
@@ -10,27 +10,57 @@ from ..utils import needs_bash
 from . import colon_example as mod
 
 
+def _extract_complete_var(script: str) -> str:
+    match = re.search(r"(\_[A-Z0-9_.]+_COMPLETE)=complete_bash", script)
+    assert match is not None, "bash completion script missing complete_bash env var"
+    return match.group(1)
+
+
 def _bash_completion_reply(
-    script: str,
     *,
-    wrapper_dir: Path,
+    python_cmd: str,
+    complete_var: str,
     comp_line: str,
-    comp_words: str,
-    comp_cword: str,
 ) -> str:
     bash = shutil.which("bash")
     if bash is None:
         raise RuntimeError("bash not found")
+
+    # Call Python the same way other completion tests do, so the autocomplete
+    # env var matches --show-completion. Avoid PATH wrappers that change argv[0].
     with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
         handle.write(
             f"""
-set -euo pipefail
-export PATH={wrapper_dir}:{os.environ.get("PATH", "")}
-{script}
 COMP_LINE={comp_line!r}
 COMP_POINT=${{#COMP_LINE}}
-COMP_WORDS=({comp_words})
-COMP_CWORD={comp_cword}
+COMP_WORDBREAKS=$' \\t\\n\"\\'@><=;|&(:'
+_colon_examplepy_completion() {{
+    local __line=${{COMP_LINE:0:COMP_POINT}}
+    local -a __words
+    read -ra __words <<< "$__line"
+    local __cword=${{#__words[@]}}
+    [[ $__line != *[[:space:]] ]] && __cword=$((__cword - 1))
+    local __full=${{__words[__cword]-}}
+
+    local IFS=$'\\n'
+    local -a __raw
+    __raw=( $( env COMP_WORDS="${{__words[*]}}" \\
+                   COMP_CWORD=$__cword \\
+                   {complete_var}=complete_bash {python_cmd} ) ) || true
+
+    local __wordbreaks="$COMP_WORDBREAKS"
+    if [[ -z "$__wordbreaks" ]]; then
+        __wordbreaks=$' \\t\\n\"\\'@><=;|&(:'
+    fi
+    local __cur=${{__full##*[$__wordbreaks]}}
+    local __strip=$(( ${{#__full}} - ${{#__cur}} ))
+    COMPREPLY=()
+    local __c
+    for __c in "${{__raw[@]}}"; do
+        COMPREPLY+=( "${{__c:__strip}}" )
+    done
+    return 0
+}}
 _colon_examplepy_completion colon_example.py
 printf '%s\\n' "${{COMPREPLY[@]}}"
 """
@@ -70,24 +100,15 @@ def test_bash_completion_script_handles_comp_wordbreaks_colon() -> None:
     )
     assert show.returncode == 0
     assert "COMP_LINE" in show.stdout
-    assert "COMP_WORDBREAKS" in show.stdout
+    assert "__wordbreaks" in show.stdout or "COMP_WORDBREAKS" in show.stdout
 
-    with tempfile.TemporaryDirectory() as tmp:
-        wrapper_dir = Path(tmp)
-        wrapper = wrapper_dir / "colon_example.py"
-        wrapper.write_text(
-            f'#!/bin/sh\nexec {sys.executable} -m coverage run {mod.__file__} "$@"\n'
-        )
-        wrapper.chmod(
-            wrapper.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-        )
-
-        reply = _bash_completion_reply(
-            show.stdout,
-            wrapper_dir=wrapper_dir,
-            comp_line="colon_example.py --name alpine:l",
-            comp_words="colon_example.py --name : l",
-            comp_cword="3",
-        )
+    complete_var = _extract_complete_var(show.stdout)
+    python_cmd = f"{sys.executable} -m coverage run {Path(mod.__file__).as_posix()}"
+    reply = _bash_completion_reply(
+        python_cmd=python_cmd,
+        complete_var=complete_var,
+        # COMP_LINE keeps the full token; bash would have split on ':' in COMP_WORDS.
+        comp_line="colon_example.py --name alpine:l",
+    )
     assert "latest" in reply.splitlines()
     assert "alpine:latest" not in reply

--- a/tests/test_completion/test_completion_bash_wordbreaks.py
+++ b/tests/test_completion/test_completion_bash_wordbreaks.py
@@ -6,25 +6,24 @@ import sys
 import tempfile
 from pathlib import Path
 
-from . import colon_example as mod
-
 from ..utils import needs_bash
+from . import colon_example as mod
 
 
 def _bash_completion_reply(
-  script: str,
-  *,
-  wrapper_dir: Path,
-  comp_line: str,
-  comp_words: str,
-  comp_cword: str,
+    script: str,
+    *,
+    wrapper_dir: Path,
+    comp_line: str,
+    comp_words: str,
+    comp_cword: str,
 ) -> str:
-  bash = shutil.which("bash")
-  if bash is None:
-    raise RuntimeError("bash not found")
-  with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
-    handle.write(
-      f"""
+    bash = shutil.which("bash")
+    if bash is None:
+        raise RuntimeError("bash not found")
+    with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
+        handle.write(
+            f"""
 set -euo pipefail
 export PATH={wrapper_dir}:{os.environ.get("PATH", "")}
 {script}
@@ -35,58 +34,60 @@ COMP_CWORD={comp_cword}
 _colon_examplepy_completion colon_example.py
 printf '%s\\n' "${{COMPREPLY[@]}}"
 """
-    )
-    path = handle.name
-  try:
-    result = subprocess.run(
-      [bash, "--norc", path],
-      capture_output=True,
-      encoding="utf-8",
-      env={**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)},
-    )
-  finally:
-    Path(path).unlink(missing_ok=True)
-  assert result.returncode == 0, result.stderr
-  return result.stdout
+        )
+        path = handle.name
+    try:
+        result = subprocess.run(
+            [bash, "--norc", path],
+            capture_output=True,
+            encoding="utf-8",
+            env={**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)},
+        )
+    finally:
+        Path(path).unlink(missing_ok=True)
+    assert result.returncode == 0, result.stderr
+    return result.stdout
 
 
 @needs_bash
 def test_bash_completion_script_handles_comp_wordbreaks_colon() -> None:
-  show = subprocess.run(
-    [
-      sys.executable,
-      "-m",
-      "coverage",
-      "run",
-      mod.__file__,
-      "--show-completion",
-      "bash",
-    ],
-    capture_output=True,
-    encoding="utf-8",
-    env={
-      **os.environ,
-      "_TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION": "True",
-    },
-  )
-  assert show.returncode == 0
-  assert "COMP_LINE" in show.stdout
-  assert "COMP_WORDBREAKS" in show.stdout
-
-  with tempfile.TemporaryDirectory() as tmp:
-    wrapper_dir = Path(tmp)
-    wrapper = wrapper_dir / "colon_example.py"
-    wrapper.write_text(
-      f"#!/bin/sh\nexec {sys.executable} -m coverage run {mod.__file__} \"$@\"\n"
+    show = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            mod.__file__,
+            "--show-completion",
+            "bash",
+        ],
+        capture_output=True,
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "_TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION": "True",
+        },
     )
-    wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    assert show.returncode == 0
+    assert "COMP_LINE" in show.stdout
+    assert "COMP_WORDBREAKS" in show.stdout
 
-    reply = _bash_completion_reply(
-      show.stdout,
-      wrapper_dir=wrapper_dir,
-      comp_line="colon_example.py --name alpine:l",
-      comp_words="colon_example.py --name : l",
-      comp_cword="3",
-    )
-  assert "latest" in reply.splitlines()
-  assert "alpine:latest" not in reply
+    with tempfile.TemporaryDirectory() as tmp:
+        wrapper_dir = Path(tmp)
+        wrapper = wrapper_dir / "colon_example.py"
+        wrapper.write_text(
+            f'#!/bin/sh\nexec {sys.executable} -m coverage run {mod.__file__} "$@"\n'
+        )
+        wrapper.chmod(
+            wrapper.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        )
+
+        reply = _bash_completion_reply(
+            show.stdout,
+            wrapper_dir=wrapper_dir,
+            comp_line="colon_example.py --name alpine:l",
+            comp_words="colon_example.py --name : l",
+            comp_cword="3",
+        )
+    assert "latest" in reply.splitlines()
+    assert "alpine:latest" not in reply

--- a/tests/test_completion/test_completion_bash_wordbreaks.py
+++ b/tests/test_completion/test_completion_bash_wordbreaks.py
@@ -6,6 +6,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from ..utils import needs_bash, skip_if_windows
 from . import colon_example as mod
 
@@ -75,6 +77,19 @@ printf '%s\\n' "${{COMPREPLY[@]}}"
         Path(path).unlink(missing_ok=True)
     assert result.returncode == 0, result.stderr
     return result.stdout
+
+
+def test_bash_completion_reply_requires_bash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+
+    with pytest.raises(RuntimeError, match="bash not found"):
+        _bash_completion_reply(
+            python_cmd=sys.executable,
+            complete_var="_COLON_EXAMPLEPY_COMPLETE",
+            comp_line="colon_example.py --name alpine:l",
+        )
 
 
 @skip_if_windows

--- a/tests/test_completion/test_completion_bash_wordbreaks.py
+++ b/tests/test_completion/test_completion_bash_wordbreaks.py
@@ -1,0 +1,92 @@
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from . import colon_example as mod
+
+from ..utils import needs_bash
+
+
+def _bash_completion_reply(
+  script: str,
+  *,
+  wrapper_dir: Path,
+  comp_line: str,
+  comp_words: str,
+  comp_cword: str,
+) -> str:
+  bash = shutil.which("bash")
+  if bash is None:
+    raise RuntimeError("bash not found")
+  with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
+    handle.write(
+      f"""
+set -euo pipefail
+export PATH={wrapper_dir}:{os.environ.get("PATH", "")}
+{script}
+COMP_LINE={comp_line!r}
+COMP_POINT=${{#COMP_LINE}}
+COMP_WORDS=({comp_words})
+COMP_CWORD={comp_cword}
+_colon_examplepy_completion colon_example.py
+printf '%s\\n' "${{COMPREPLY[@]}}"
+"""
+    )
+    path = handle.name
+  try:
+    result = subprocess.run(
+      [bash, "--norc", path],
+      capture_output=True,
+      encoding="utf-8",
+      env={**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)},
+    )
+  finally:
+    Path(path).unlink(missing_ok=True)
+  assert result.returncode == 0, result.stderr
+  return result.stdout
+
+
+@needs_bash
+def test_bash_completion_script_handles_comp_wordbreaks_colon() -> None:
+  show = subprocess.run(
+    [
+      sys.executable,
+      "-m",
+      "coverage",
+      "run",
+      mod.__file__,
+      "--show-completion",
+      "bash",
+    ],
+    capture_output=True,
+    encoding="utf-8",
+    env={
+      **os.environ,
+      "_TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION": "True",
+    },
+  )
+  assert show.returncode == 0
+  assert "COMP_LINE" in show.stdout
+  assert "COMP_WORDBREAKS" in show.stdout
+
+  with tempfile.TemporaryDirectory() as tmp:
+    wrapper_dir = Path(tmp)
+    wrapper = wrapper_dir / "colon_example.py"
+    wrapper.write_text(
+      f"#!/bin/sh\nexec {sys.executable} -m coverage run {mod.__file__} \"$@\"\n"
+    )
+    wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    reply = _bash_completion_reply(
+      show.stdout,
+      wrapper_dir=wrapper_dir,
+      comp_line="colon_example.py --name alpine:l",
+      comp_words="colon_example.py --name : l",
+      comp_cword="3",
+    )
+  assert "latest" in reply.splitlines()
+  assert "alpine:latest" not in reply

--- a/tests/test_completion/test_completion_bash_wordbreaks.py
+++ b/tests/test_completion/test_completion_bash_wordbreaks.py
@@ -26,8 +26,6 @@ def _bash_completion_reply(
     if bash is None:
         raise RuntimeError("bash not found")
 
-    # Call Python the same way other completion tests do, so the autocomplete
-    # env var matches --show-completion. Avoid PATH wrappers that change argv[0].
     with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
         handle.write(
             f"""
@@ -107,7 +105,6 @@ def test_bash_completion_script_handles_comp_wordbreaks_colon() -> None:
     reply = _bash_completion_reply(
         python_cmd=python_cmd,
         complete_var=complete_var,
-        # COMP_LINE keeps the full token; bash would have split on ':' in COMP_WORDS.
         comp_line="colon_example.py --name alpine:l",
     )
     assert "latest" in reply.splitlines()

--- a/typer/_completion_shared.py
+++ b/typer/_completion_shared.py
@@ -31,9 +31,13 @@ COMPLETION_SCRIPT_BASH = """
     local -a __raw
     __raw=( $( env COMP_WORDS="${__words[*]}" \\
                    COMP_CWORD=$__cword \\
-                   %(autocomplete_var)s=complete_bash $1 ) )
+                   %(autocomplete_var)s=complete_bash $1 ) ) || true
 
-    local __cur=${__full##*[$COMP_WORDBREAKS]}
+    local __wordbreaks="$COMP_WORDBREAKS"
+    if [[ -z "$__wordbreaks" ]]; then
+        __wordbreaks=$' \t\n"\'><=;|&(:'
+    fi
+    local __cur=${__full##*[$__wordbreaks]}
     local __strip=$(( ${#__full} - ${#__cur} ))
     COMPREPLY=()
     local __c

--- a/typer/_completion_shared.py
+++ b/typer/_completion_shared.py
@@ -20,10 +20,26 @@ class Shells(str, Enum):
 
 COMPLETION_SCRIPT_BASH = """
 %(complete_func)s() {
+    local __line=${COMP_LINE:0:COMP_POINT}
+    local -a __words
+    read -ra __words <<< "$__line"
+    local __cword=${#__words[@]}
+    [[ $__line != *[[:space:]] ]] && __cword=$((__cword - 1))
+    local __full=${__words[__cword]-}
+
     local IFS=$'\n'
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \\
-                   COMP_CWORD=$COMP_CWORD \\
+    local -a __raw
+    __raw=( $( env COMP_WORDS="${__words[*]}" \\
+                   COMP_CWORD=$__cword \\
                    %(autocomplete_var)s=complete_bash $1 ) )
+
+    local __cur=${__full##*[$COMP_WORDBREAKS]}
+    local __strip=$(( ${#__full} - ${#__cur} ))
+    COMPREPLY=()
+    local __c
+    for __c in "${__raw[@]}"; do
+        COMPREPLY+=( "${__c:__strip}" )
+    done
     return 0
 }
 

--- a/typer/_completion_shared.py
+++ b/typer/_completion_shared.py
@@ -29,8 +29,8 @@ COMPLETION_SCRIPT_BASH = """
 
     local IFS=$'\n'
     local -a __raw
-    __raw=( $( env COMP_WORDS="${__words[*]}" \\
-                   COMP_CWORD=$__cword \\
+    __raw=( $( env COMP_WORDS="${__words[*]}" \
+                   COMP_CWORD=$__cword \
                    %(autocomplete_var)s=complete_bash $1 ) ) || true
 
     local __wordbreaks="$COMP_WORDBREAKS"


### PR DESCRIPTION
## Summary

Fixes #1905.

Bash splits `COMP_WORDS` on `COMP_WORDBREAKS` (including `:`) before the compspec runs, so values like `alpine:latest` arrived as separate tokens and completion saw the wrong `incomplete` prefix.

## Changes

Updated `COMPLETION_SCRIPT_BASH` in `typer/_completion_shared.py` to:

1. Rebuild the active word list from `COMP_LINE` / `COMP_POINT` before calling Typer
2. Strip the `COMP_WORDBREAKS`-delimited suffix from each candidate before inserting into `COMPREPLY` (so bash appends `latest` after `alpine:` instead of replacing with `alpine:latest`)
3. Tolerate unset `COMP_WORDBREAKS` and helper failures so the compspec does not abort mid-completion

## Test plan

- [x] `pytest tests/test_completion/test_completion_bash_wordbreaks.py`
- [x] `pytest tests/test_completion/` (full suite)
- [x] Integration case: split `COMP_WORDS=(prog --name : l)` with `COMP_LINE="prog --name alpine:l"` completes to `alpine:latest`

**Label request:** this is a bug fix — please add the `bug` label so `check-labels` can pass (contributors cannot set it).
