### PR TITLE
🐛 Fix showing `fast` button as external link in animated terminals in docs

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -86,6 +86,9 @@ a[data-internal-link][target="_blank"]:not(:has(img)):not(.no-link-icon):not(.an
 a[data-internal-link][target="_blank"]:not(:has(img)):not(.no-link-icon):not(.announce-link):hover::after {
   opacity: 0.85;
 }
+a[data-terminal-control] {
+    cursor: pointer;
+}
 
 /* Disable link icons in footer and header nav */
 .md-footer a::after,

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -86,9 +86,6 @@ a[data-internal-link][target="_blank"]:not(:has(img)):not(.no-link-icon):not(.an
 a[data-internal-link][target="_blank"]:not(:has(img)):not(.no-link-icon):not(.announce-link):hover::after {
   opacity: 0.85;
 }
-a[data-terminal-control] {
-    cursor: pointer;
-}
 
 /* Disable link icons in footer and header nav */
 .md-footer a::after,

--- a/docs/css/termynal.css
+++ b/docs/css/termynal.css
@@ -66,6 +66,10 @@ button[data-terminal-control] {
     font: inherit;
 }
 
+button[data-terminal-control]:hover {
+    color: var(--color-text);
+}
+
 [data-ty] {
     display: block;
     line-height: 2;

--- a/docs/css/termynal.css
+++ b/docs/css/termynal.css
@@ -55,11 +55,15 @@
     text-align: center;
 }
 
-a[data-terminal-control] {
+button[data-terminal-control] {
     cursor: pointer;
     text-align: right;
     display: block;
+    width: 100%;
     color: #aebbff;
+    border: 0;
+    background: transparent;
+    font: inherit;
 }
 
 [data-ty] {

--- a/docs/css/termynal.css
+++ b/docs/css/termynal.css
@@ -56,6 +56,7 @@
 }
 
 a[data-terminal-control] {
+    cursor: pointer;
     text-align: right;
     display: block;
     color: #aebbff;

--- a/docs/js/termynal.js
+++ b/docs/js/termynal.js
@@ -133,7 +133,7 @@ class Termynal {
             this.container.innerHTML = ''
             this.init()
         }
-        restart.href = '#'
+        restart.href = 'javascript:void(0)'
         restart.setAttribute('data-terminal-control', '')
         restart.innerHTML = "restart ↻"
         return restart
@@ -147,7 +147,7 @@ class Termynal {
             this.typeDelay = 0
             this.startDelay = 0
         }
-        finish.href = '#'
+        finish.href = 'javascript:void(0)'
         finish.setAttribute('data-terminal-control', '')
         finish.innerHTML = "fast →"
         this.finishElement = finish

--- a/docs/js/termynal.js
+++ b/docs/js/termynal.js
@@ -133,7 +133,7 @@ class Termynal {
             this.container.innerHTML = ''
             this.init()
         }
-        restart.href = 'javascript:void(0)'
+
         restart.setAttribute('data-terminal-control', '')
         restart.innerHTML = "restart ↻"
         return restart
@@ -147,7 +147,7 @@ class Termynal {
             this.typeDelay = 0
             this.startDelay = 0
         }
-        finish.href = 'javascript:void(0)'
+
         finish.setAttribute('data-terminal-control', '')
         finish.innerHTML = "fast →"
         this.finishElement = finish

--- a/docs/js/termynal.js
+++ b/docs/js/termynal.js
@@ -130,8 +130,7 @@ class Termynal {
         const restart = document.createElement('button')
         restart.type = 'button'
 
-        restart.onclick = (e) => {
-            e.preventDefault()
+        restart.onclick = () => {
             this.container.innerHTML = ''
             this.init()
         }
@@ -145,8 +144,7 @@ class Termynal {
         const finish = document.createElement('button')
         finish.type = 'button'
 
-        finish.onclick = (e) => {
-            e.preventDefault()
+        finish.onclick = () => {
             this.lineDelay = 0
             this.typeDelay = 0
             this.startDelay = 0

--- a/docs/js/termynal.js
+++ b/docs/js/termynal.js
@@ -127,7 +127,9 @@ class Termynal {
     }
 
     generateRestart() {
-        const restart = document.createElement('a')
+        const restart = document.createElement('button')
+        restart.type = 'button'
+
         restart.onclick = (e) => {
             e.preventDefault()
             this.container.innerHTML = ''
@@ -140,7 +142,9 @@ class Termynal {
     }
 
     generateFinish() {
-        const finish = document.createElement('a')
+        const finish = document.createElement('button')
+        finish.type = 'button'
+
         finish.onclick = (e) => {
             e.preventDefault()
             this.lineDelay = 0


### PR DESCRIPTION
## Pull Request

Discussion: #1908 

## Description

### Problem
`fast` and `restart` were marked as hyperlinks, it seems that under first initial load the page would render them as true hyperlinks, adding an icon that indicates to users that it will open a new tab and also not adhering to its styling (which is rather to the top right). 
_Read more on the discussion page for details._

### Solution
- Removing the hyperlink reference and implemented button elements.
- Updated CSS to preserve the controls existing appearance as much as possible. 

### Note on small UI issues:
~~- Upon scolling down to the bottom of the page, then clicking `fast` on a terminal widget, the content-side-bar overlaps the bottom content - slightly (if the side-bar is long enough).~~ (I can't reproduce this after 09ede97f21226d6530a00cfdca155ce51681276b)
- Minor issue with multiple terminal widgets besides eachother, one might get pushed slightly down the page (as seen in this video): https://github.com/user-attachments/assets/6eefddc4-7f05-4656-bdb0-2e15982697a7

>Note: These two problems are quite *minor* edge-cases, I don't think there is a need to handle them in this PR - as I do not believe this PR is relevant to fix these issues - nonetheless I wanted to mention them as I see them more openly when I make this fix. 

## AI Disclaimer
I used ChatGPT 5.5 (High) to help investigate the issue. The final solution was determined and implemented manually.

## Checklist

- [X] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [X] Coverage stays at 100%.
- [X] The documentation explains the change if needed.
