### PR TITLE
Fix atomic writes replacing destinations after command failures

### DIFF
--- a/tests/test_atomic_file.py
+++ b/tests/test_atomic_file.py
@@ -3,8 +3,12 @@ import sys
 from pathlib import Path
 
 import pytest
+import typer
+from typer.testing import CliRunner
 
 from . import atomic_write_example as mod
+
+runner = CliRunner()
 
 
 def test_atomic_write(tmp_path: Path) -> None:
@@ -87,6 +91,41 @@ def test_atomic_api(tmp_path: Path) -> None:
     assert "repr=<_io.TextIOWrapper" in result.stdout
     assert "entered=True" in result.stdout
     assert output_file.read_text(encoding="utf-8") == "atomic-api-done\n"
+
+
+@pytest.mark.parametrize("lazy", [True, False], ids=["lazy", "eager"])
+@pytest.mark.parametrize(
+    "destination_exists", [True, False], ids=["existing", "missing"]
+)
+def test_atomic_write_callback_failure(
+    tmp_path: Path, lazy: bool, destination_exists: bool
+) -> None:
+    original_content = "existing-content\n"
+    output_file = tmp_path / "atomic-failure-target.txt"
+    if destination_exists:
+        output_file.write_text(original_content, encoding="utf-8")
+    initial_entries = set(tmp_path.iterdir())
+
+    app = typer.Typer()
+
+    @app.command()
+    def write_atomic_failure(
+        config: typer.FileTextWrite = typer.Option(..., atomic=True, lazy=lazy),
+    ) -> None:
+        config.write("partial-content\n")
+        config.flush()
+        raise RuntimeError("callback failed")
+
+    result = runner.invoke(app, [f"--config={output_file}"])
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, RuntimeError)
+    assert str(result.exception) == "callback failed"
+    if destination_exists:
+        assert output_file.read_text(encoding="utf-8") == original_content
+    else:
+        assert not output_file.exists()
+    assert set(tmp_path.iterdir()) == initial_entries
 
 
 @pytest.mark.parametrize(

--- a/typer/_click/_compat.py
+++ b/typer/_click/_compat.py
@@ -416,7 +416,13 @@ class _AtomicFile:
         if self.closed:
             return  # pragma: no cover
         self._f.close()
-        os.replace(self._tmp_filename, self._real_filename)
+        if delete:
+            try:
+                os.unlink(self._tmp_filename)
+            except OSError:  # pragma: no cover
+                pass
+        else:
+            os.replace(self._tmp_filename, self._real_filename)
         self.closed = True
 
     def __getattr__(self, name: str) -> Any:

--- a/typer/_click/types.py
+++ b/typer/_click/types.py
@@ -539,7 +539,10 @@ class File(ParamType):
                 )
 
                 if ctx is not None:
-                    ctx.call_on_close(lf.close_intelligently)
+                    if self.atomic:
+                        ctx.with_resource(lf)
+                    else:
+                        ctx.call_on_close(lf.close_intelligently)
 
                 return cast("IO[Any]", lf)
 
@@ -554,7 +557,10 @@ class File(ParamType):
             # type is used with prompts.
             if ctx is not None:
                 if should_close:
-                    ctx.call_on_close(safecall(f.close))
+                    if self.atomic:
+                        ctx.with_resource(f)
+                    else:
+                        ctx.call_on_close(safecall(f.close))
                 else:
                     ctx.call_on_close(safecall(f.flush))
 

--- a/typer/_click/utils.py
+++ b/typer/_click/utils.py
@@ -182,7 +182,10 @@ class LazyFile:
         exc_value: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        self.close_intelligently()
+        if self.atomic and self.should_close and self._f is not None:
+            self._f.__exit__(exc_type, exc_value, tb)
+        else:
+            self.close_intelligently()
 
     def __iter__(self) -> Iterator[AnyStr]:
         self.open()


### PR DESCRIPTION
## Summary

- register atomic file parameters as exception-aware context resources
- forward callback exceptions through lazy atomic files
- discard temporary output instead of replacing the destination after failures
- add regression tests for lazy and eager files

## Problem

File parameters configured with `atomic=True` replace the destination even
when the command callback raises an exception after writing partial content.

This defeats the purpose of atomic output and can replace an existing valid
file with incomplete data.

The issue affects both `lazy=True` and `lazy=False`.

## Fix

Atomic files are now registered with `Context.with_resource()` so their
context managers receive the active exception.

`LazyFile` forwards the exception information to its underlying atomic
stream, and `_AtomicFile.close(delete=True)` removes the temporary file
instead of replacing the destination.

Non-atomic file cleanup behavior is unchanged.

## Tests

Regression coverage verifies both lazy modes when:

- the destination already exists
- the destination does not exist
- the command writes and flushes partial content before raising
- the original callback exception is preserved
- no temporary file is leaked

Validation results:

- atomic file tests: 10 passed
- full test suite: 1390 passed, 12 skipped, 2 xfailed
- Ruff lint and formatting checks passed

Related upstream report: pallets/click#3221