### PR TITLE
👷 Remove Zensical docs cache

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -67,10 +67,6 @@ jobs:
             uv.lock
       - name: Install docs extras
         run: uv sync --locked --no-dev --group docs
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          key: mkdocs-cards-${{ github.ref }}-v1
-          path: .cache
       - name: Build Docs
         run: uv run ./scripts/docs.py build
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Description

Remove caching of Zensical's `.cache` from the docs workflow.

Zensical's cache invalidation does not account for all documentation sources or YAML data changes, so restoring the cache can generate outdated content. This mirrors fastapi/fastapi#16156.

## AI Disclaimer

Using Codex with gpt-5.6-sol. Reviewed manually.
