### PR TITLE
DOC: fix comment grammar in typer/completion.py

### DIFF
--- a/typer/completion.py
+++ b/typer/completion.py
@@ -100,7 +100,7 @@ def _install_completion_no_auto_placeholder_function(
 # Re-implement Click's shell_complete to add error message with:
 # Invalid completion instruction
 # To use 7.x instruction style for compatibility
-# And to add extra error messages, for compatibility with Typer in previous versions
+# To add extra error messages, for compatibility with Typer in previous versions
 # This is only called in new Command method, only used by Click 8.x+
 def shell_complete(
     cli: _click.Command,


### PR DESCRIPTION
Small documentation/comment grammar fix in `typer/completion.py`.

Removed a dangling leading `And` from a comment in `shell_complete` so the comment list reads cleanly:

```
# To add extra error messages, for compatibility with Typer in previous versions
```

Docs/typo only — no functional changes.