### PR TITLE
docs: add module docstring in colors.py and fix punctuation in testing.py

### DIFF
--- a/typer/colors.py
+++ b/typer/colors.py
@@ -1,4 +1,5 @@
-# Variable names to colors, just for completion
+"""Color constants for terminal styling and completion."""
+
 BLACK = "black"
 RED = "red"
 GREEN = "green"

--- a/typer/testing.py
+++ b/typer/testing.py
@@ -54,7 +54,7 @@ class StreamMixer:
         self.stderr: io.BytesIO = BytesIOCopy(copy_to=self.output)
 
     def __del__(self) -> None:
-        """Guarantee that file-like objects are closed in a predictable order"""
+        """Guarantee that file-like objects are closed in a predictable order."""
         self.stderr.close()
         self.stdout.close()
         self.output.close()


### PR DESCRIPTION
### Summary
- Add module docstring in `typer/colors.py`.
- Fix missing trailing period in `typer/testing.py` `StreamMixer.__del__` docstring.