### PR TITLE
Keep the sub-app's deprecated flag in add_typer()

### DIFF
--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,6 +1,9 @@
 import pytest
 import typer
+import typer.core
 from typer.testing import CliRunner
+
+from tests.utils import needs_rich
 
 runner = CliRunner()
 
@@ -23,3 +26,35 @@ def test_deprecation():
         match="The 'is_flag' and 'flag_value' parameters are not supported by Typer"
     ):
         add_command()
+
+
+@pytest.mark.parametrize(
+    ("use_rich", "expected"),
+    [
+        pytest.param(False, "(DEPRECATED)"),
+        pytest.param(True, "(deprecated)", marks=needs_rich),
+    ],
+)
+def test_add_typer_keeps_sub_app_deprecated(
+    monkeypatch: pytest.MonkeyPatch, use_rich: bool, expected: str
+) -> None:
+    """A sub-app that marks itself deprecated stays deprecated once added.
+
+    ``add_typer()`` has to leave its own ``deprecated`` default as a
+    ``Default()`` placeholder, otherwise it reads as an explicit argument and
+    overrides the value the sub-app set on itself.
+    """
+    monkeypatch.setattr(typer.core, "HAS_RICH", use_rich)
+
+    app = typer.Typer()
+    sub_app = typer.Typer(deprecated=True)
+
+    @sub_app.command()
+    def sub_command() -> None:
+        """Sub command."""  # pragma: no cover
+
+    app.add_typer(sub_app, name="sub")
+
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert expected in result.output

--- a/typer/main.py
+++ b/typer/main.py
@@ -1073,7 +1073,7 @@ class Typer:
                 Mark this command as deprecated in the help outputs. `False` by default.
                 """
             ),
-        ] = False,
+        ] = Default(False),
         # Rich settings
         rich_help_panel: Annotated[
             str | None,


### PR DESCRIPTION
`Typer.add_typer()` declares its `deprecated` parameter as a plain `False`, while every other setting in the same signature uses the `Default()` sentinel — including `hidden`, which sits directly above it:

```python
        hidden: Annotated[...] = Default(False),
        deprecated: Annotated[...] = False,          # <- the odd one out
```

`solve_typer_info_defaults()` uses that sentinel to tell "the caller passed this to `add_typer()`" apart from "the caller said nothing":

```python
        # Priority 1: Value was set in app.add_typer()
        if not isinstance(value, DefaultPlaceholder):
            values[name] = value
            continue
        # Priority 2: Value was set in @subapp.callback()
        ...
        # Priority 3: Value set in subapp = typer.Typer()
```

A bare `False` is not a `DefaultPlaceholder`, so Priority 1 always fires and Priorities 2 and 3 are never reached. A sub-app that marked *itself* deprecated silently loses that flag the moment it is added to a parent.

### Reproduction

```python
import typer

app = typer.Typer()
sub_app = typer.Typer(deprecated=True)

@sub_app.command()
def sub_command():
    """Sub command."""

app.add_typer(sub_app, name="sub")
```

`--help` on the parent:

```
│ sub                                                                          │
```

expected:

```
│ sub                                                            (deprecated)  │
```

### Why this is the default and not a judgement call

Two controls, same shape, both behave correctly:

| Case | Result |
|---|---|
| `sub_app = typer.Typer(hidden=True)` — sibling, `Default()`-wrapped | ✅ propagates |
| `app.add_typer(sub_app, deprecated=True)` — passed at the call site | ✅ shows `(deprecated)` |
| `sub_app = typer.Typer(deprecated=True)` — this bug | ❌ silently dropped |

So the plumbing is fine end to end; only the default is wrong.

`TyperInfo` is constructed in exactly three places, and all three flow through `solve_typer_info_defaults()`:

| | `deprecated` default |
|---|---|
| `Typer.__init__` | `Default(False)` |
| `Typer.callback()` | `Default(False)` |
| `Typer.add_typer()` | `False` ← |

`Typer.command()` also uses a bare `False`, but that one builds a `CommandInfo`, which never goes through the solver — so it is correctly different and is left alone here.

### Change

One token: `] = False,` → `] = Default(False),`. `Default` is already imported in the module.

### Tests

Added `test_add_typer_keeps_sub_app_deprecated` to `tests/test_deprecation.py`, parametrised over rich / non-rich the same way `tests/test_hidden.py` does, since the marker renders as `(deprecated)` under Rich and `(DEPRECATED)` without it.

- Against `master`: **both parametrisations fail**
- With the change: pass
- Full suite before: 1379 passed, 18 skipped, 2 xfailed
- Full suite after: 1381 passed, 18 skipped, 2 xfailed — no other test changes behaviour
- `ruff check` and `ruff format --check` clean on both changed files
- `mypy typer` reports the same 6 pre-existing errors before and after (identical set); none in `main.py`
