### PR TITLE
docs: fix grammar in TyperChoice._normalized_mapping docstring

### DIFF
--- a/typer/_types.py
+++ b/typer/_types.py
@@ -23,7 +23,7 @@ class TyperChoice(types.ParamType, Generic[ParamTypeValue]):
         self, ctx: _click.Context | None = None
     ) -> Mapping[ParamTypeValue, str]:
         """
-        Returns mapping where keys are the original choices and the values are
+        Return a mapping where keys are the original choices and the values are
         the normalized values that are accepted via the command line.
         """
         return {


### PR DESCRIPTION
### Summary
- Add missing article 'a' to `TyperChoice._normalized_mapping` docstring in `typer/_types.py` (`Returns mapping where` -> `Return a mapping where`).