### PR TITLE
refactor: remove unused OptionHelpExtra TypedDict from _click.types

### DIFF
--- a/typer/_click/types.py
+++ b/typer/_click/types.py
@@ -9,7 +9,6 @@ from typing import (
     ClassVar,
     Literal,
     NoReturn,
-    TypedDict,
     TypeGuard,
     TypeVar,
     Union,
@@ -686,10 +685,3 @@ BOOL = BoolParamType()
 
 # A UUID parameter.
 UUID = UUIDParameterType()
-
-
-class OptionHelpExtra(TypedDict, total=False):
-    envvars: tuple[str, ...]
-    default: str
-    range: str
-    required: str


### PR DESCRIPTION
## Pull Request

Discussion: https://github.com/fastapi/typer/discussions/1937

## Description

`OptionHelpExtra` in `typer/_click/types.py` is a `TypedDict` vendored from
Click 8.3.1. In Click it annotates the return value of `Option.get_help_extra()`.
Typer's vendored `_click` never included that method, and Typer's own help-record
assembly (`typer/core.py`) does not use the type. As a result `OptionHelpExtra`
is referenced nowhere in the codebase and is not part of any public API surface:
it lives in the private `typer/_click` package and is not re-exported by
`typer/__init__.py` or `typer/_click/__init__.py`.

This PR:
- Deletes the unused `OptionHelpExtra` `TypedDict`.
- Removes the now-unused `TypedDict` import from `typer/_click/types.py`.

No runtime behavior or public-API change. If Typer later re-vendors Click's
`get_help_extra()` path, the type can be reintroduced alongside its caller.

## AI Disclaimer

Models: Composer 2.5 (via Cursor + [VinvAI](https://vinv.ai/) )

Prompt (paraphrased): act on Vinv's dead-code finding for `OptionHelpExtra` —
confirm the symbol is genuinely unreferenced (no static references, no
re-export from any package `__init__` or public API surface, no dynamic lookup
by name, and no `get_help_extra` caller in Typer's vendored `_click`), then
delete it along with any now-unused imports or types that existed solely to
support it.

<details>
<summary>AI transcript</summary>

* Vinv's dead-code sweep flagged `OptionHelpExtra` in `typer/_click/types.py`
  as unreferenced; the removal was implemented via Composer 2.5 (Cursor + VinvAI).
* Independently verified before finalizing:
   * Repo-wide grep for `OptionHelpExtra` → only the definition site matched.
   * Confirmed `get_help_extra` (the method it annotates in upstream Click) does
     not exist anywhere in Typer's vendored `_click`.
   * Confirmed it is not re-exported (`typer/__init__.py`,
     `typer/_click/__init__.py`, `__all__`) and not resolved dynamically.
   * Confirmed the `TypedDict` import had no other users.
* Deleted `OptionHelpExtra` and the now-unused `TypedDict` import.
* Ran `python -m py_compile typer/_click/types.py` → compiles clean. (Full
  pytest/coverage suite not run in this session.)

</details>

## Checklist

- [x] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change. <!-- N/A: removal of unreferenced code with no runtime behavior; no code path to test. -->
- [ ] The new or updated tests fail on the main branch and pass on this PR. <!-- N/A, see above. -->
- [ ] Coverage stays at 100%. <!-- Verify with the project's coverage run (e.g. bash scripts/test.sh) before ticking. -->
- [ ] The documentation explains the change if needed. <!-- N/A: no documented behavior changes. -->