### PR TITLE
Fix OptionHighlighter regex incorrectly highlighting comparison operators as metavars

### DIFF
--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -112,7 +112,7 @@ class OptionHighlighter(RegexHighlighter):
     highlights = [
         r"(^|\W)(?P<switch>\-\w+)(?![a-zA-Z0-9])",
         r"(^|\W)(?P<option>\-\-[\w\-]+)(?![a-zA-Z0-9])",
-        r"(?P<types>\<[^\>]+\>)",
+        r"(?P<types>\<\S(?:[^\>]*\S)?\>)",
         r"(?P<usage>Usage: )",
     ]
 


### PR DESCRIPTION
Fixes #1637 (via discussion)

## Problem

`OptionHighlighter` in `rich_utils.py` uses the regex `\<[^\>]+\>` for the `types` group, which greedily matches everything between the first `<` and the next `>` in a help string. When a CLI option's help text contains comparison operators (e.g. `"Operators: <= (less/equal) and > (greater)"`), the entire span `<= (less/equal) and >` gets incorrectly highlighted as a metavar type.

## Fix

Replace the regex with `\<\S(?:[^\>]*\S)?\>`, which requires non-whitespace characters immediately after `<` and before `>`. This correctly:

- Rejects prose like `<= (less/equal) and >` (space before `>`)
- Matches single-word metavars like `<FILENAME>` and `<str>`
- Preserves typer's own `DateTime` format metavar `<%Y-%m-%d|%Y-%m-%dT%H:%M:%S|%Y-%m-%d %H:%M:%S>` which contains internal spaces but has non-whitespace boundaries

Verified against typer 0.27.1 on Python 3.14: broken render vs fixed render confirmed.

## Disclosure

This fix was developed with AI assistance (GitHub Copilot). The bug analysis, regex design, edge case identification (DateTime metavar), and local verification were human-reviewed.