### PR TITLE
♻️ Create `exceptions` module and `TyperException` base class

### DIFF
--- a/typer/__init__.py
+++ b/typer/__init__.py
@@ -5,9 +5,7 @@ __version__ = "0.27.1"
 from shutil import get_terminal_size as get_terminal_size
 
 from . import colors as colors
-from ._click.exceptions import Abort as Abort
 from ._click.exceptions import BadParameter as BadParameter
-from ._click.exceptions import Exit as Exit
 from ._click.termui import confirm as confirm
 from ._click.termui import getchar as getchar
 from ._click.termui import progressbar as progressbar
@@ -19,6 +17,9 @@ from ._click.utils import format_filename as format_filename
 from ._click.utils import get_app_dir as get_app_dir
 from ._click.utils import get_binary_stream as get_binary_stream
 from ._click.utils import get_text_stream as get_text_stream
+from .exceptions import Abort as Abort
+from .exceptions import Exit as Exit
+from .exceptions import TyperException as TyperException
 from .main import Typer as Typer
 from .main import launch as launch
 from .main import run as run

--- a/typer/_click/core.py
+++ b/typer/_click/core.py
@@ -16,15 +16,9 @@ from typing import (
     overload,
 )
 
+from ..exceptions import Abort, Exit
 from . import types
-from .exceptions import (
-    Abort,
-    BadParameter,
-    Exit,
-    MissingParameter,
-    NoArgsIsHelpError,
-    UsageError,
-)
+from .exceptions import BadParameter, MissingParameter, NoArgsIsHelpError, UsageError
 from .formatting import HelpFormatter
 from .globals import pop_context, push_context
 from .parser import _OptionParser

--- a/typer/_click/exceptions.py
+++ b/typer/_click/exceptions.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from typing import IO, TYPE_CHECKING, Any, Union
 
+from ..exceptions import TyperException
 from ._compat import get_text_stderr
 from .globals import resolve_color_default
 from .utils import echo, format_filename
@@ -16,20 +17,14 @@ def _join_param_hints(param_hint: Sequence[str] | str | None) -> str | None:
     return param_hint
 
 
-class ClickException(Exception):
+class ClickException(TyperException):
     """An exception that Click can handle and show to the user."""
-
-    exit_code = 1
 
     def __init__(self, message: str) -> None:
         super().__init__(message)
         # The context will be removed by the time we print the message, so cache
         # the color settings here to be used later on (in `show`)
         self.show_color: bool | None = resolve_color_default()
-        self.message = message
-
-    def format_message(self) -> str:
-        return self.message
 
     def __str__(self) -> str:
         return self.message
@@ -243,18 +238,3 @@ class FileError(ClickException):
 
     def format_message(self) -> str:
         return f"Could not open file {self.ui_filename!r}: {self.message}"
-
-
-class Abort(RuntimeError):
-    """An internal signalling exception that signals Click to abort."""
-
-
-class Exit(RuntimeError):
-    """An exception that indicates that the application should exit with some
-    status code.
-    """
-
-    __slots__ = ("exit_code",)
-
-    def __init__(self, code: int = 0) -> None:
-        self.exit_code: int = code

--- a/typer/_click/exceptions.py
+++ b/typer/_click/exceptions.py
@@ -26,9 +26,6 @@ class ClickException(TyperException):
         # the color settings here to be used later on (in `show`)
         self.show_color: bool | None = resolve_color_default()
 
-    def __str__(self) -> str:
-        return self.message
-
     def show(self, file: IO[Any] | None = None) -> None:
         if file is None:
             file = get_text_stderr()

--- a/typer/_click/termui.py
+++ b/typer/_click/termui.py
@@ -3,7 +3,8 @@ from collections.abc import Callable, Iterable
 from contextlib import AbstractContextManager
 from typing import IO, TYPE_CHECKING, Any, AnyStr, TextIO, TypeVar, overload
 
-from .exceptions import Abort, UsageError
+from ..exceptions import Abort
+from .exceptions import UsageError
 from .globals import resolve_color_default
 from .types import ParamType, convert_type
 from .utils import LazyFile, echo

--- a/typer/_completion_shared.py
+++ b/typer/_completion_shared.py
@@ -8,6 +8,7 @@ import shellingham
 
 from . import _click
 from ._click.globals import get_current_context
+from .exceptions import Exit
 
 
 class Shells(str, Enum):
@@ -81,7 +82,7 @@ def get_completion_script(*, prog_name: str, complete_var: str, shell: str) -> s
     script = _completion_scripts.get(shell)
     if script is None:
         _click.echo(f"Shell {shell} not supported.", err=True)
-        raise _click.exceptions.Exit(1)
+        raise Exit(1)
     return (
         script
         % {
@@ -175,7 +176,7 @@ def install_powershell(*, prog_name: str, complete_var: str, shell: str) -> Path
     )
     if result.returncode != 0:  # pragma: no cover
         _click.echo("Couldn't get PowerShell user profile", err=True)
-        raise _click.exceptions.Exit(result.returncode)
+        raise Exit(result.returncode)
     path_str = ""
     if isinstance(result.stdout, str):  # pragma: no cover
         path_str = result.stdout
@@ -188,7 +189,7 @@ def install_powershell(*, prog_name: str, complete_var: str, shell: str) -> Path
                 pass
         if not path_str:  # pragma: no cover
             _click.echo("Couldn't decode the path automatically", err=True)
-            raise _click.exceptions.Exit(1)
+            raise Exit(1)
     path_obj = Path(path_str.strip())
     parent_dir: Path = path_obj.parent
     parent_dir.mkdir(parents=True, exist_ok=True)
@@ -234,7 +235,7 @@ def install(
         return shell, installed_path
     else:
         _click.echo(f"Shell {shell} is not supported.")
-        raise _click.exceptions.Exit(1)
+        raise Exit(1)
 
 
 def _get_shell_name() -> str | None:

--- a/typer/core.py
+++ b/typer/core.py
@@ -18,6 +18,7 @@ from ._click import types
 from ._click.parser import _OptionParser
 from ._click.shell_completion import CompletionItem
 from ._typing import Literal
+from .exceptions import Abort, Exit
 from .utils import parse_boolean_env_var
 
 MarkupMode = Literal["markdown", "rich", None]
@@ -165,13 +166,10 @@ def _main(
     rich_markup_mode: MarkupMode = DEFAULT_MARKUP_MODE,
     **extra: Any,
 ) -> Any:
-    # Typer override, duplicated from _click.main() to handle custom rich exceptions
-    # Verify that the environment is configured correctly, or reject
-    # further execution to avoid a broken script.
+    # Originally copied from _click.main(), adopted to handle custom rich exceptions etc
     if args is None:
         args = sys.argv[1:]
 
-        # Covered in Click tests
         if os.name == "nt" and windows_expand_args:  # pragma: no cover
             args = _click.utils._expand_args(args)
     else:
@@ -199,20 +197,18 @@ def _main(
                 ctx.exit()
         except EOFError as e:
             _click.echo(file=sys.stderr)
-            raise _click.exceptions.Abort() from e
+            raise Abort() from e
         except KeyboardInterrupt as e:
-            raise _click.exceptions.Exit(130) from e
+            raise Exit(130) from e
         except _click.exceptions.ClickException as e:
             if not standalone_mode:
                 raise
-            # Typer override
             if HAS_RICH and rich_markup_mode is not None:
                 from . import rich_utils
 
                 rich_utils.rich_format_error(e)
             else:
                 e.show()
-            # Typer override end
             sys.exit(e.exit_code)
         except OSError as e:
             if e.errno == errno.EPIPE:
@@ -221,7 +217,7 @@ def _main(
                 sys.exit(1)
             else:
                 raise
-    except _click.exceptions.Exit as e:
+    except Exit as e:
         if standalone_mode:
             sys.exit(e.exit_code)
         else:
@@ -234,17 +230,15 @@ def _main(
             # `ctx.exit(1)` and to `return 1`, the caller won't be able to
             # tell the difference between the two
             return e.exit_code
-    except _click.exceptions.Abort:
+    except Abort:
         if not standalone_mode:
             raise
-        # Typer override
         if HAS_RICH and rich_markup_mode is not None:
             from . import rich_utils
 
             rich_utils.rich_abort_error()
         else:
             _click.echo(_("Aborted!"), file=sys.stderr)
-        # Typer override end
         sys.exit(1)
 
 

--- a/typer/exceptions.py
+++ b/typer/exceptions.py
@@ -7,6 +7,9 @@ class TyperException(Exception):
         super().__init__(message)
         self.message = message
 
+    def __str__(self) -> str:
+        return self.message
+
     def format_message(self) -> str:
         return self.message
 

--- a/typer/exceptions.py
+++ b/typer/exceptions.py
@@ -1,0 +1,26 @@
+class TyperException(Exception):
+    """A Typer-specific exception"""
+
+    exit_code = 1
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+    def format_message(self) -> str:
+        return self.message
+
+
+class Abort(RuntimeError):
+    """An internal signalling exception that signals Typer to abort."""
+
+
+class Exit(RuntimeError):
+    """An exception that indicates that the application should exit with some
+    status code.
+    """
+
+    __slots__ = ("exit_code",)
+
+    def __init__(self, code: int = 0) -> None:
+        self.exit_code: int = code


### PR DESCRIPTION
## Pull Request

Discussion: https://github.com/fastapi/typer/discussions/1832

## Description

Continuing from the original [Click vendoring](https://github.com/fastapi/typer/pull/1774), this PR introduces a new base class `TyperException` that all other exception classes inherit from. This is to replace a check for `ClickException` (which some users may want to do, cf discusssion thread) which is currently in the private module `_click` and shouldn't be used/imported directly. The "old" Click exception hierarchy will be refactored in the near future and shouldn't be used directly either.

`Abort` and `Exit` have always been part of the public Typer API and as such they are moved into the new Typer module.

## AI Disclaimer

No AI used, just good old fashioned human communication & thinking. Refreshing :sunglasses: 

## Checklist

- [x] This PR links to a GitHub Discussion for the proposed code change.
- [x] Coverage stays at 100%.
- [x] The documentation explains the change if needed.
