### PR TITLE
Fix Rich help terminal width

### DIFF
--- a/tests/test_cli/test_help.py
+++ b/tests/test_cli/test_help.py
@@ -174,7 +174,6 @@ def test_typer_run_usage() -> None:
     assert "Try 'typer [PATH_OR_MODULE] run --help' for help." in result.output
 
 
-
 def test_terminal_width_with_rich() -> None:
     app = typer.Typer()
 
@@ -182,8 +181,7 @@ def test_terminal_width_with_rich() -> None:
     def cmd(
         name: str = typer.Option(
             help=(
-                "A very long help message that should wrap when "
-                "the terminal is narrow."
+                "A very long help message that should wrap when the terminal is narrow."
             ),
         ),
     ) -> None:

--- a/tests/test_cli/test_help.py
+++ b/tests/test_cli/test_help.py
@@ -172,3 +172,31 @@ def test_typer_run_usage() -> None:
     usage_line = result.output.splitlines()[0]
     assert usage_line.startswith("Usage: typer [PATH_OR_MODULE] run [OPTIONS] {name}")
     assert "Try 'typer [PATH_OR_MODULE] run --help' for help." in result.output
+
+
+
+def test_terminal_width_with_rich() -> None:
+    app = typer.Typer()
+
+    @app.command()
+    def cmd(
+        name: str = typer.Option(
+            help=(
+                "A very long help message that should wrap when "
+                "the terminal is narrow."
+            ),
+        ),
+    ) -> None:
+        pass
+
+    result = runner.invoke(
+        app,
+        ["cmd", "--help"],
+        terminal_width=40,
+    )
+
+    assert result.exit_code == 0
+
+    output_lines = result.output.splitlines()
+
+    assert all(len(line) <= 40 for line in output_lines)

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -164,6 +164,8 @@ def _get_rich_console(
         width=width if width is not None else MAX_WIDTH,
         stderr=stderr,
     )
+
+
 def _make_rich_text(
     *, text: str, style: str = "", markup_mode: MarkupModeStrict
 ) -> Markdown | Text:

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -142,7 +142,10 @@ def _has_ansi_character(text: str) -> bool:
     return ANSI_PREFIX in text
 
 
-def _get_rich_console(stderr: bool = False) -> Console:
+def _get_rich_console(
+    stderr: bool = False,
+    width: int | None = None,
+) -> Console:
     return Console(
         theme=Theme(
             {
@@ -158,11 +161,9 @@ def _get_rich_console(stderr: bool = False) -> Console:
         highlighter=highlighter,
         color_system=COLOR_SYSTEM,
         force_terminal=FORCE_TERMINAL,
-        width=MAX_WIDTH,
+        width=width if width is not None else MAX_WIDTH,
         stderr=stderr,
     )
-
-
 def _make_rich_text(
     *, text: str, style: str = "", markup_mode: MarkupModeStrict
 ) -> Markdown | Text:
@@ -566,7 +567,7 @@ def rich_format_help(
     Replacement for the click function format_help().
     Takes a command or group and builds the help text output.
     """
-    console = _get_rich_console()
+    console = _get_rich_console(width=ctx.terminal_width)
 
     # Print usage
     console.print(


### PR DESCRIPTION
## Pull Request

Discussion: https://github.com/fastapi/typer/discussions/1944

## Description

### Problem

When Typer renders help using Rich, `CliRunner(..., terminal_width=...)` was not respected.

The requested terminal width is stored in the Click context as `ctx.terminal_width`, but the Rich console was using `MAX_WIDTH` instead. This caused Rich-formatted help output to exceed the terminal width requested by `CliRunner`.

### Fix

Pass `ctx.terminal_width` to Typer's Rich console when formatting help.

The existing `MAX_WIDTH` behavior remains the fallback when no explicit width is provided.

### Tests

Added a regression test verifying that Rich-formatted help respects the terminal width supplied through `CliRunner`.

Full test suite:

* 1384 passed
* 18 skipped
* 2 xfailed

## AI Disclaimer

This pull request was developed with assistance from an AI coding assistant (GPT-5.6 Luna).

<details>
<summary>AI transcript</summary>

<!-- Paste the complete AI transcript required by the project here. -->

</details>

## Checklist

* [x] This PR links to a GitHub Discussion for the proposed code change.
* [x] I added tests for the change.
* [x] The new or updated tests fail on the main branch and pass on this PR.
* [ ] Coverage stays at 100%.
* [ ] The documentation explains the change if needed.
