### PR TITLE
Write generated docs as UTF-8 in typer utils docs --output

### DIFF
--- a/tests/assets/cli/non_ascii_help.py
+++ b/tests/assets/cli/non_ascii_help.py
@@ -1,0 +1,9 @@
+import typer
+
+app = typer.Typer()
+
+
+@app.command()
+def greet(name: str = "World"):
+    """Say hi to someone ✨ with café flair."""
+    typer.echo(f"Hello {name}")  # pragma: no cover

--- a/tests/test_cli/test_non_ascii_docs_output.py
+++ b/tests/test_cli/test_non_ascii_docs_output.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from ..utils import skip_if_windows
+
+
+@skip_if_windows
+def test_docs_output_does_not_depend_on_the_locale_encoding(tmp_path: Path):
+    """The written file must not go through the process locale encoding.
+
+    Forcing an ASCII locale here stands in for the cp1252 default on Windows:
+    under the locale encoding this raised UnicodeEncodeError on any help text
+    holding a character that encoding cannot represent.
+    """
+    out_path = tmp_path / "docs.md"
+    env = {
+        **os.environ,
+        "LC_ALL": "C",
+        "PYTHONUTF8": "0",
+        "PYTHONCOERCECLOCALE": "0",
+    }
+    env.pop("LANG", None)
+    env.pop("LC_CTYPE", None)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            "-m",
+            "typer",
+            "tests/assets/cli/non_ascii_help.py",
+            "utils",
+            "docs",
+            "--output",
+            str(out_path),
+        ],
+        capture_output=True,
+        encoding="utf-8",
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "✨" in out_path.read_text(encoding="utf-8")
+    assert "café" in out_path.read_text(encoding="utf-8")

--- a/typer/cli.py
+++ b/typer/cli.py
@@ -307,7 +307,7 @@ def docs(
     docs = get_docs_for_click(obj=click_obj, ctx=ctx, name=name, title=title)
     clean_docs = f"{docs.strip()}\n"
     if output:
-        output.write_text(clean_docs)
+        output.write_text(clean_docs, encoding="utf-8")
         typer.echo(f"Docs saved to: {output}")
     else:
         typer.echo(clean_docs)


### PR DESCRIPTION
Closes #1881.

`typer <app> utils docs --output FILE` writes the generated Markdown with `output.write_text(clean_docs)`, which goes through the platform's default encoding. On interpreters whose locale encoding is not UTF-8 (cp1252 on Windows being the common case), any help text holding a character that encoding cannot represent raises `UnicodeEncodeError` - reproduced today on Linux with `LC_ALL=C PYTHONUTF8=0` against the emoji example from #1881.

The fix is the one #1881 asks for: write the file as UTF-8 explicitly, which matches how the docs are meant to be consumed (Markdown tooling assumes UTF-8) and makes the output independent of the machine that generated it.

Includes a regression test that runs `utils docs --output` in a subprocess under a forced ASCII locale and asserts the file is written and round-trips the non-ASCII help text.
