### PR TITLE
✅ Fix flaky `app_dir` and `launch` tutorial tests under `xdist`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+import pytest
+import typer
+
+
+@pytest.fixture(name="app_dir")
+def patch_app_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(typer, "get_app_dir", lambda _app_name: str(tmp_path))
+    return tmp_path

--- a/tests/test_tutorial/test_app_dir/test_tutorial001.py
+++ b/tests/test_tutorial/test_app_dir/test_tutorial001.py
@@ -2,8 +2,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-import typer
 from typer.testing import CliRunner
 
 from docs_src.app_dir import tutorial001_py310 as mod
@@ -11,26 +9,14 @@ from docs_src.app_dir import tutorial001_py310 as mod
 runner = CliRunner()
 
 
-@pytest.fixture(name="config_file")
-def create_config_file():
-    app_dir = Path(typer.get_app_dir("my-super-cli-app"))
-    app_dir.mkdir(parents=True, exist_ok=True)
-    config_path = app_dir / "config.json"
-    config_path.touch(exist_ok=True)
-
-    yield config_path
-
-    config_path.unlink()
-    app_dir.rmdir()
-
-
-def test_cli_config_doesnt_exist():
+def test_cli_config_doesnt_exist(app_dir: Path):
     result = runner.invoke(mod.app)
     assert result.exit_code == 0
     assert "Config file doesn't exist yet" in result.output
 
 
-def test_cli_config_exists(config_file: Path):
+def test_cli_config_exists(app_dir: Path):
+    (app_dir / "config.json").touch()
     result = runner.invoke(mod.app)
     assert result.exit_code == 0
     assert "Config file doesn't exist yet" not in result.output

--- a/tests/test_tutorial/test_launch/test_tutorial002.py
+++ b/tests/test_tutorial/test_launch/test_tutorial002.py
@@ -3,30 +3,11 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-import typer
 from typer.testing import CliRunner
 
 from docs_src.launch import tutorial002_py310 as mod
 
 runner = CliRunner()
-
-
-@pytest.fixture(name="app_dir")
-def app_dir():
-    app_dir = Path(typer.get_app_dir("my-super-cli-app"))
-    if app_dir.exists():  # pragma: no cover
-        for item in app_dir.iterdir():
-            if item.is_file():
-                item.unlink()
-
-    yield app_dir
-
-    if app_dir.exists():
-        for item in app_dir.iterdir():
-            if item.is_file():
-                item.unlink()
-        app_dir.rmdir()
 
 
 def test_cli(app_dir: Path):

--- a/tests/test_types_file.py
+++ b/tests/test_types_file.py
@@ -9,7 +9,7 @@ from typer._click._compat import get_best_encoding, should_strip_ansi
 from typer._click.utils import PacifyFlushWrapper
 from typer.testing import CliRunner
 
-from tests.utils import needs_linux, needs_windows
+from tests.utils import needs_linux, needs_macos, needs_windows
 
 app = typer.Typer()
 
@@ -300,6 +300,33 @@ def test_app_dir_force_posix(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("os.path.expanduser", lambda _path: "/home/tester/.my-app")
 
     assert typer.get_app_dir("My App", force_posix=True) == "/home/tester/.my-app"
+
+
+@needs_linux
+def test_app_dir_linux_xdg_config_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/home/tester/config")
+
+    assert typer.get_app_dir("My App") == "/home/tester/config/my-app"
+
+
+@needs_linux
+def test_app_dir_linux_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setattr("os.path.expanduser", lambda _path: "/home/tester/.config")
+
+    assert typer.get_app_dir("My App") == "/home/tester/.config/my-app"
+
+
+@needs_macos
+def test_app_dir_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "os.path.expanduser", lambda _path: "/Users/tester/Library/Application Support"
+    )
+
+    assert (
+        typer.get_app_dir("My App")
+        == "/Users/tester/Library/Application Support/My App"
+    )
 
 
 def test_text_stream_binary_buffer(monkeypatch) -> None:


### PR DESCRIPTION
## Description

I noticed that `test-redistribute` failed on `master` (see [logs](https://github.com/fastapi/typer/actions/runs/33624907165)), but passed again on later commits.

After investigating it with Claude Code we found a race between `xdist` workers. Three tests use the real `~/.config/my-super-cli-app/config.json`:

* `test_cli_config_doesnt_exist` expects the file to not exist
* `test_cli_config_exists` creates it in a fixture
* `test_cli` in `test_launch/test_tutorial002.py` creates it via the tutorial code

`xdist` spreads tests across workers, so these tests run in parallel from time to time and then may fail.

To fix this I added an `app_dir` fixture in `tests/conftest.py`. It patches `typer.get_app_dir` to return `tmp_path`, so each test gets its own empty dir.
As a bonus, tests no longer create files in the real `~/.config` on developers' machines.

To reproduce the flakiness on `master`:

```
for i in $(seq 1 15); do pytest tests/test_tutorial/test_app_dir tests/test_tutorial/test_launch -n 4 -q -o addopts="" | grep failed; done
```

## AI Disclaimer

Used Claude Code (Fable 5.1) to investigate and apply the fix. Reviewed manually

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [x] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
